### PR TITLE
hdl/examples/Blinky: optimize clock divide circuit.

### DIFF
--- a/hdl/examples/Blinky.bsv
+++ b/hdl/examples/Blinky.bsv
@@ -8,8 +8,11 @@ interface Blinky #(numeric type clk_f);
 endinterface
 
 module mkBlinky (Blinky#(clk_f))
-        provisos (Log#(clk_f, count_sz));
-    Reg#(UInt#(count_sz)) c <- mkRegA(0);
+        provisos (Log#(clk_f, count_sz),
+                  Add#(reload_sz, 1, count_sz));
+    let reload = fromInteger(valueof(clk_f) / 2 - 1);
+
+    Reg#(UInt#(reload_sz)) c <- mkRegA(reload);
     Reg#(Bit#(1)) d0 <- mkRegA(0);
     Reg#(Bit#(1)) d1 <- mkRegA(0);
 
@@ -17,11 +20,11 @@ module mkBlinky (Blinky#(clk_f))
 
     (* no_implicit_conditions, fire_when_enabled *)
     rule do_blink;
-        let overflow = c >= fromInteger(valueof(clk_f) / 2);
-        c <= overflow ? 0 : c + 1;
+        let zero = c == 0;
+        c <= zero ? reload : c - 1;
 
         // Write the LED bits.
-        d0 <= overflow ? ~d0 : d0;
+        d0 <= zero ? ~d0 : d0;
         d1 <= button_pressed_ ? 1 : 0;
     endrule
 


### PR DESCRIPTION
- Shrink the counter by one bit, since it only ever counts through half
  of the clk_f period.

- Switch the overflow comparison to compare equality with zero, rather
  than comparing magnitude with the halfway point -- comparing equality
  with a constant can be done bit-parallel using LUTs, while magnitude
  comparison requires a carry chain.

- Switch the counter to a down-counter, so that the "zero" event
  triggers "reload" cycles after starting, like before.

- Fix off-by-one in the counter period. (It was counting for clk_f/2+1
  cycles.)

On iCE40, where I'm mostly testing, this reduces area by 38% and
shortens the critical path by 25%-60% (depending on place and route).