### PR TITLE
Add rudimentary ECP5 PLL wrapper/abstraction

### DIFF
--- a/hdl/BUILD
+++ b/hdl/BUILD
@@ -19,6 +19,11 @@ bluespec_library('Encoding8b10b',
         ':TestUtils',
     ])
 
+bluespec_library('PLL',
+    sources = [
+        'PLL.bsv'
+    ])
+
 bluespec_library('Strobe',
     sources = [
         'Strobe.bsv'

--- a/hdl/PLL.bsv
+++ b/hdl/PLL.bsv
@@ -1,0 +1,24 @@
+// Copyright 2021 Oxide Computer Company
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package PLL;
+
+export PLL(..);
+
+import Vector::*;
+
+//
+// PLL(..) is an attempt at a generic PLL interface with a variable number of output clocks. This
+// interface is currently used to abstract the PLL primitives provided for ECP5 FPGA devices but may
+// need to evolve to accomodate other devices and our understanding of clocks in Bluespec.
+//
+interface PLL #(numeric type n_output_clocks);
+    interface Clock in;
+    method Vector#(n_output_clocks, Clock) out();
+    method Bool locked();
+endinterface
+
+endpackage: PLL

--- a/hdl/boards/ecp5_evn/BUILD
+++ b/hdl/boards/ecp5_evn/BUILD
@@ -13,6 +13,7 @@ bluespec_verilog('examples',
     modules = [
         'mkBlinky',
         'mkUARTLoopback',
+        'mkClocks',
     ],
     deps = [
         ':Board',
@@ -56,4 +57,25 @@ nextpnr_ecp5_bitstream('uart_loopback_ecp5_evn',
     design = ':uart_loopback#uart_loopback.json',
     deps = [
         ':uart_loopback',
+    ])
+
+# Clocks/PLL design targets
+
+yosys_design('clocks',
+    top_module = 'mkClocks',
+    sources = [
+        ':examples#mkClocks',
+        '../../interfaces/ECP5PLL.v', # This is a hack, we should improve this.
+        '//vnd/bluespec:Verilog.v#Verilog.v',
+    ],
+    deps = [
+        ':examples',
+        '//vnd/bluespec:Verilog.v',
+    ])
+
+nextpnr_ecp5_bitstream('clocks_ecp5_evn',
+    env = 'ecp5_evn',
+    design = ':clocks#clocks.json',
+    deps = [
+        ':clocks',
     ])

--- a/hdl/boards/ecp5_evn/Examples.bsv
+++ b/hdl/boards/ecp5_evn/Examples.bsv
@@ -55,4 +55,69 @@ module mkUARTLoopback (TopMinimal);
     endmethod
 endmodule
 
-endpackage : Examples
+//
+// mkClocks is a minimal example which demonstrates the ECP5 PLL wrapper and how to clock different
+// parts of a design using independent clocks. This example should blink the first two LEDs in phase
+// at 1Hz.
+//
+(* synthesize, default_clock_osc="CLK_12mhz", default_reset="GSR_N" *)
+module mkClocks (TopMinimal);
+    GSR gsr <- mkGSR(); // Allow GSR_N to reset the design.
+
+    let pll_parameters = ECP5PLLParameters {
+        clki_frequency: 12.0,
+        clki_divide: 3,
+        // Primary output clock parameters.
+        clkop_enable: True,
+        clkop_frequency: 100.0,
+        clkop_divide: 6,
+        clkop_coarse_phase_adjust: 0,
+        clkop_fine_phase_adjust: 0,
+        // Secondary output clock parameters.
+        clkos_enable: True,
+        clkos_frequency: 50.0,
+        clkos_divide: 12,
+        clkos_coarse_phase_adjust: 0,
+        clkos_fine_phase_adjust: 0,
+        // Secondary output clock 2 parameters.
+        clkos2_enable: False,
+        clkos2_frequency: 0.0,
+        clkos2_divide: 0,
+        clkos2_coarse_phase_adjust: 0,
+        clkos2_fine_phase_adjust: 0,
+        // Secondary output clock 3 parameters.
+        clkos3_enable: False,
+        clkos3_frequency: 0.0,
+        clkos3_divide: 0,
+        clkos3_coarse_phase_adjust: 0,
+        clkos3_fine_phase_adjust: 0,
+        // Feedback parameters.
+        feedback_path: "CLKOP",
+        feedback_divide: 25};
+
+    Clock clk_12mhz <- exposeCurrentClock();
+    Reset rst_12mhz <- exposeCurrentReset();
+    ECP5PLL pll <- mkECP5PLL(pll_parameters, clk_12mhz, rst_12mhz);
+
+    Blinky#(100_000_000) blinky_100mhz <- Blinky::mkBlinky(clocked_by pll.clkop);
+    Blinky#(50_000_000) blinky_50mhz <- Blinky::mkBlinky(clocked_by pll.clkos);
+
+    let led0 = blinky_100mhz.led[0];
+    let led1 = blinky_50mhz.led[0];
+    let led2 = blinky_100mhz.led[1] | blinky_50mhz.led[1];
+    method led = {~'0, led2, led1, led0};
+
+    method Action btn(Bit#(1) val);
+        if (val != 0) begin
+            blinky_100mhz.button_pressed();
+            blinky_50mhz.button_pressed();
+        end
+    endmethod
+
+    // Ignore UART.
+    method uart_tx = 1;
+    method Action uart_rx(val);
+    endmethod
+endmodule
+
+endpackage: Examples

--- a/hdl/interfaces/BUILD
+++ b/hdl/interfaces/BUILD
@@ -3,7 +3,14 @@
 bluespec_library('ECP5',
     sources = [
         'ECP5.bsv',
+    ],
+    deps = [
+        '//hdl:PLL',
     ])
+
+#
+# UART package and unit tests.
+#
 
 bluespec_library('UART',
     sources = [

--- a/hdl/interfaces/ECP5.bsv
+++ b/hdl/interfaces/ECP5.bsv
@@ -7,12 +7,26 @@
 package ECP5;
 
 //
+// The ECP5 package provides wrappers around various ECP5 primitives. These are currently only
+// tested against recent versions of Yosys/Nextpnr, but should in theory work with the Lattice
+// provided synthesis toolchain.
+//
+
+export GSR(..), mkGSR;
+export ECP5PLLParameters(..), ECP5PLL(..), mkECP5PLL, mkPLL;
+
+import DefaultValue::*;
+import Vector::*;
+
+import PLL::*;
+
+
+//
 // GSR primitive, which provides a global reset of the fabric using a user signal. This is
 // effectively the same as a PoR and can be used for external reset.
 //
 // Note: this currently uses the default reset of the module instantiating this primitive.
 //
-
 interface GSR;
 endinterface
 
@@ -22,4 +36,175 @@ import "BVI" GSR =
         default_reset gsr (GSR);
     endmodule
 
-endpackage : ECP5
+//
+// ECP5PLL(..) is an interface to the ECP5PLL module found in the adjacent Verilog file. See
+// vMkECP5PLL for details how this maps on the wrapper and EHXPLLL primitive and see Lattice Semi
+// "FPGA-TN-02200-1.2" and the Lattice Semi "FPGA Libraries Reference Guide" on how this primitive
+// works.
+//
+interface ECP5PLL;
+    // Primary output clock of the PLL.
+    interface Clock clkop;
+    // Secondary output clocks of the PLL. These can be either be integer divisions or phase shifted
+    // from the primary output clock.
+    interface Clock clkos;
+    interface Clock clkos2;
+    interface Clock clkos3;
+    // The `lock` signal of the EXHPLLL primitive is negative asserted.
+    method Bool not_lock();
+endinterface
+
+//
+// ECP5 PLL parameters. See Section 18 in Lattice Semi "FPGA-TN-02200-1.2" for valid values and
+// expected behavior.
+//
+typedef struct {
+    // Input clock parameters.
+    Real clki_frequency;
+    Integer clki_divide;
+    // Primary output clock parameters.
+    Bool clkop_enable;
+    Real clkop_frequency;
+    Integer clkop_divide;
+    Integer clkop_coarse_phase_adjust;
+    Integer clkop_fine_phase_adjust;
+    // Secondary output clock parameters.
+    Bool clkos_enable;
+    Real clkos_frequency;
+    Integer clkos_divide;
+    Integer clkos_coarse_phase_adjust;
+    Integer clkos_fine_phase_adjust;
+    // Secondary output clock 2 parameters.
+    Bool clkos2_enable;
+    Real clkos2_frequency;
+    Integer clkos2_divide;
+    Integer clkos2_coarse_phase_adjust;
+    Integer clkos2_fine_phase_adjust;
+    // Secondary output clock 3 parameters.
+    Bool clkos3_enable;
+    Real clkos3_frequency;
+    Integer clkos3_divide;
+    Integer clkos3_coarse_phase_adjust;
+    Integer clkos3_fine_phase_adjust;
+    // Feedback parameters.
+    String feedback_path;
+    Integer feedback_divide;
+} ECP5PLLParameters;
+
+instance DefaultValue #(ECP5PLLParameters);
+    defaultValue = ECP5PLLParameters {
+        clki_frequency: 0.0,
+        clki_divide: 0,
+        // Primary output clock parameters.
+        clkop_enable: False,
+        clkop_frequency: 0.0,
+        clkop_divide: 0,
+        clkop_coarse_phase_adjust: 0,
+        clkop_fine_phase_adjust: 0,
+        // Secondary output clock parameters.
+        clkos_enable: False,
+        clkos_frequency: 0.0,
+        clkos_divide: 0,
+        clkos_coarse_phase_adjust: 0,
+        clkos_fine_phase_adjust: 0,
+        // Secondary output clock 2 parameters.
+        clkos2_enable: False,
+        clkos2_frequency: 0.0,
+        clkos2_divide: 0,
+        clkos2_coarse_phase_adjust: 0,
+        clkos2_fine_phase_adjust: 0,
+        // Secondary output clock 3 parameters.
+        clkos3_enable: False,
+        clkos3_frequency: 0.0,
+        clkos3_divide: 0,
+        clkos3_coarse_phase_adjust: 0,
+        clkos3_fine_phase_adjust: 0,
+        // Feedback parameters.
+        feedback_path: "CLKOP",
+        feedback_divide: 1};
+endinstance
+
+import "BVI" ECP5PLL =
+    module vMkECP5PLL #(ECP5PLLParameters parameters, Clock clk_in, Reset rst) (ECP5PLL);
+        parameter CLKI_FREQUENCY = realToString(parameters.clki_frequency);
+        parameter CLKI_DIV = parameters.clki_divide;
+        parameter CLKOP_ENABLE = parameters.clkop_enable ? "ENABLED" : "DISABLED";
+        parameter CLKOP_FREQUENCY = realToString(parameters.clkop_frequency);
+        parameter CLKOP_DIV = parameters.clkop_divide;
+        parameter CLKOP_CPHASE = parameters.clkop_coarse_phase_adjust;
+        parameter CLKOP_FPHASE = parameters.clkop_fine_phase_adjust;
+        parameter CLKOS_ENABLE = parameters.clkos_enable ? "ENABLED" : "DISABLED";
+        parameter CLKOS_FREQUENCY = realToString(parameters.clkos_frequency);
+        parameter CLKOS_DIV = parameters.clkos_divide;
+        parameter CLKOS_CPHASE = parameters.clkos_coarse_phase_adjust;
+        parameter CLKOS_FPHASE = parameters.clkos_fine_phase_adjust;
+        parameter CLKOS2_ENABLE = parameters.clkos2_enable ? "ENABLED" : "DISABLED";
+        parameter CLKOS2_FREQUENCY = realToString(parameters.clkos2_frequency);
+        parameter CLKOS2_DIV = parameters.clkos2_divide;
+        parameter CLKOS2_CPHASE = parameters.clkos2_coarse_phase_adjust;
+        parameter CLKOS2_FPHASE = parameters.clkos2_fine_phase_adjust;
+        parameter CLKOS3_ENABLE = parameters.clkos3_enable ? "ENABLED" : "DISABLED";
+        parameter CLKOS3_FREQUENCY = realToString(parameters.clkos3_frequency);
+        parameter CLKOS3_DIV = parameters.clkos3_divide;
+        parameter CLKOS3_CPHASE = parameters.clkos3_coarse_phase_adjust;
+        parameter CLKOS3_FPHASE = parameters.clkos3_fine_phase_adjust;
+        parameter FB_DIV = parameters.feedback_divide;
+        parameter FB_PATH = parameters.feedback_path;
+
+        default_clock clki(CLKI, CLKI_GATE) = clk_in;
+        default_reset rst = rst;
+
+        // TODO (arjen): determine how to add output clock gating without breaking
+        // `no_implicit_conditions` assertions in modules clocked by these outputs.
+        port CLKOP_GATE = 1'b0;
+        port CLKOS_GATE = 1'b0;
+        port CLKOS2_GATE = 1'b0;
+        port CLKOS3_GATE = 1'b0;
+
+        output_clock clkop(CLKOP);
+        output_clock clkos(CLKOS);
+        output_clock clkos2(CLKOS2);
+        output_clock clkos3(CLKOS3);
+
+        same_family (clki, clkop);
+        same_family (clki, clkos);
+        same_family (clki, clkos2);
+        same_family (clki, clkos3);
+
+        method LOCK not_lock() clocked_by(no_clock);
+
+        schedule not_lock CF not_lock;
+    endmodule
+
+//
+// Instantiate an ECP5PLL with the given parameters.
+//
+module mkECP5PLL #(ECP5PLLParameters parameters, Clock clk_in, Reset rst) (ECP5PLL);
+    let pll <- vMkECP5PLL(parameters, clk_in, rst);
+    return pll;
+endmodule
+
+//
+// Instantiate a generic PLL with the given parameters. This is experimental and likely to change.
+//
+module mkPLL #(ECP5PLLParameters parameters, Clock clk_in, Reset rst) (PLL#(n_output_clocks));
+    ECP5PLL _pll <- mkECP5PLL(parameters, clk_in, rst);
+
+    interface Clock in = clk_in;
+
+    method Vector#(n_output_clocks, Clock) out();
+        // TODO (arjen): This generates a compiler warning. Determine how to improve this.
+        Vector#(n_output_clocks, Clock) cs;
+
+        if (valueOf(n_output_clocks) >= fromInteger(1)) cs[0] = _pll.clkop;
+        if (valueOf(n_output_clocks) >= fromInteger(2)) cs[1] = _pll.clkos;
+        if (valueOf(n_output_clocks) >= fromInteger(3)) cs[2] = _pll.clkos2;
+        if (valueOf(n_output_clocks) >= fromInteger(3)) cs[3] = _pll.clkos3;
+
+        return cs;
+    endmethod
+
+    method locked = !_pll.not_lock;
+endmodule
+
+endpackage: ECP5

--- a/hdl/interfaces/ECP5PLL.v
+++ b/hdl/interfaces/ECP5PLL.v
@@ -1,0 +1,110 @@
+// Copyright 2021 Oxide Computer Company
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// This file was generated using the `ecppll` utility, part of nextpnr-ecp5 and edited to provide
+// additional parameters and signals.
+
+// diamond 3.7 accepts this PLL
+// diamond 3.8-3.9 is untested
+// diamond 3.10 or higher is likely to abort with error about unable to use feedback signal
+// cause of this could be from wrong CPHASE/FPHASE parameters
+module ECP5PLL
+#(
+    parameter CLKI_FREQUENCY = "",
+    parameter CLKI_DIV = 0,
+    parameter CLKOP_ENABLE = "",
+    parameter CLKOP_FREQUENCY = "",
+    parameter CLKOP_DIV = 0,
+    parameter CLKOP_CPHASE = 0,
+    parameter CLKOP_FPHASE = 0,
+    parameter CLKOS_ENABLE = "",
+    parameter CLKOS_FREQUENCY = "",
+    parameter CLKOS_DIV = 0,
+    parameter CLKOS_CPHASE = 0,
+    parameter CLKOS_FPHASE = 0,
+    parameter CLKOS2_ENABLE = "",
+    parameter CLKOS2_FREQUENCY = "",
+    parameter CLKOS2_DIV = 0,
+    parameter CLKOS2_CPHASE = 0,
+    parameter CLKOS2_FPHASE = 0,
+    parameter CLKOS3_ENABLE = "",
+    parameter CLKOS3_FREQUENCY = "",
+    parameter CLKOS3_DIV = 0,
+    parameter CLKOS3_CPHASE = 0,
+    parameter CLKOS3_FPHASE = 0,
+    parameter FB_DIV = 0,
+    parameter FB_PATH = ""
+)
+(
+    input CLKI,
+    input CLKI_GATE,
+    input CLKOP_GATE,
+    input CLKOS_GATE,
+    input CLKOS2_GATE,
+    input CLKOS3_GATE,
+    output CLKOP,
+    output CLKOS,
+    output CLKOS2,
+    output CLKOS3,
+    output LOCK
+);
+    (* FREQUENCY_PIN_CLKI=CLKI_FREQUENCY *)
+    (* FREQUENCY_PIN_CLKOP=CLKOP_FREQUENCY *)
+    (* FREQUENCY_PIN_CLKOS=CLKOS_FREQUENCY *)
+    (* FREQUENCY_PIN_CLKOS2=CLKOS2_FREQUENCY *)
+    (* FREQUENCY_PIN_CLKOS3=CLKOS3_FREQUENCY *)
+    (* ICP_CURRENT="12" *) (* LPF_RESISTOR="8" *) (* MFG_ENABLE_FILTEROPAMP="1" *) (* MFG_GMCREF_SEL="2" *)
+    EHXPLLL #(
+        .PLLRST_ENA("DISABLED"),
+        .INTFB_WAKE("DISABLED"),
+        .STDBY_ENABLE("ENABLED"),
+        .DPHASE_SOURCE("DISABLED"),
+        .OUTDIVIDER_MUXA("DIVA"),
+        .OUTDIVIDER_MUXB("DIVB"),
+        .OUTDIVIDER_MUXC("DIVC"),
+        .OUTDIVIDER_MUXD("DIVD"),
+        .CLKI_DIV(CLKI_DIV),
+        .CLKOP_ENABLE(CLKOP_ENABLE),
+        .CLKOP_DIV(CLKOP_DIV),
+        .CLKOP_CPHASE(CLKOP_CPHASE),
+        .CLKOP_FPHASE(CLKOP_FPHASE),
+        .CLKOS_ENABLE(CLKOS_ENABLE),
+        .CLKOS_DIV(CLKOS_DIV),
+        .CLKOS_CPHASE(CLKOS_CPHASE),
+        .CLKOS_FPHASE(CLKOS_FPHASE),
+        .CLKOS2_ENABLE(CLKOS2_ENABLE),
+        .CLKOS2_DIV(CLKOS2_DIV),
+        .CLKOS2_CPHASE(CLKOS2_CPHASE),
+        .CLKOS2_FPHASE(CLKOS2_FPHASE),
+        .CLKOS3_ENABLE(CLKOS3_ENABLE),
+        .CLKOS3_DIV(CLKOS3_DIV),
+        .CLKOS3_CPHASE(CLKOS3_CPHASE),
+        .CLKOS3_FPHASE(CLKOS3_FPHASE),
+        .FEEDBK_PATH(FB_PATH),
+        .CLKFB_DIV(FB_DIV)
+    ) pll_i (
+        .RST(1'b0),
+        .STDBY(~CLKI_GATE),
+        .CLKI(CLKI),
+        .CLKOP(CLKOP),
+        .CLKOS(CLKOS),
+        .CLKOS2(CLKOS2),
+        .CLKOS3(CLKOS3),
+        .CLKFB(CLKOP),
+        .CLKINTFB(),
+        .PHASESEL0(1'b0),
+        .PHASESEL1(1'b0),
+        .PHASEDIR(1'b1),
+        .PHASESTEP(1'b1),
+        .PHASELOADREG(1'b1),
+        .PLLWAKESYNC(1'b0),
+        .ENCLKOP(CLKOP_GATE),
+        .ENCLKOS(CLKOS_GATE),
+        .ENCLKOS2(CLKOS2_GATE),
+        .ENCLKOS3(CLKOS3_GATE),
+        .LOCK(LOCK)
+    );
+endmodule


### PR DESCRIPTION
This diff adds a rudimentary wrapper around the EXHPLLL PLL primitive for the ECP5 family. You'll currently have to fill out the parameters by hand, which can be obtained by running the `ecppll` util provided by nextpnr-ecp5. Future work could port the calculations performed by that util into some Bluespec functions allowing the compiler to compute parameters at compile time.