### PR TITLE
ECP5: add wrapper for USRMCLK primitive

### DIFF
--- a/hdl/interfaces/ECP5.bsv
+++ b/hdl/interfaces/ECP5.bsv
@@ -14,6 +14,7 @@ package ECP5;
 
 export GSR(..), mkGSR;
 export ECP5PLLParameters(..), ECP5PLL(..), mkECP5PLL, mkPLL;
+export USRMCLK(..), mkUSRMCLK;
 
 import DefaultValue::*;
 import Vector::*;
@@ -206,5 +207,23 @@ module mkPLL #(ECP5PLLParameters parameters, Clock clk_in, Reset rst) (PLL#(n_ou
 
     method locked = !_pll.not_lock;
 endmodule
+
+// The USRMCLK(..) interface is a wrapper for the ECP5's USRMCLK primitive, which is
+// what controls the configuration SPI SCLK pin. Once the device enters user mode,
+// usr_mclk_in can be used to drive a user defined clock out of the pin. Additionally,
+// usr_mclk_ts can be driven to tri-state the pin.
+// Details can be found in Lattice TN1260 ECP5 and ECP5-5G sysCONFIG Usage Guide in
+// the Master SPI section.
+
+interface USRMCLK;
+    method Action usr_mclk_in((* port = "usr_mclk_in" *) Bit#(1) val);
+    method Action usr_mclk_ts((* port = "usr_mclk_ts" *) Bit#(1) val);
+endinterface
+
+import "BVI" USRMCLK =
+    module mkUSRMCLK (USRMCLK);
+        method usr_mclk_in (USRMCLKI) enable((* inhigh *) EN0);
+        method usr_mclk_ts (USRMCLKTS) enable((* inhigh *) EN1);
+    endmodule
 
 endpackage: ECP5

--- a/hdl/interfaces/USRMCLK.v
+++ b/hdl/interfaces/USRMCLK.v
@@ -1,0 +1,15 @@
+// Copyright 2022 Oxide Computer Company
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+module USRMCLK (
+    input USRMCLKI,
+    input USRMCLKTS
+);
+
+USRMCLK usrmclk_i (USRMCLKI(USRMCLKI), USRMCLKTS(USRMCLKTS))
+    /* synthesis syn_noprune=1 */;
+
+endmodule


### PR DESCRIPTION
The Master SPI SCLK pin can be controlled directly after the ECP5 enters user-mode by working through the USRMCLK primitive on the device.