### PR TITLE
Add bluesim_tests macro, refactor tests

### DIFF
--- a/hdl/BUILD
+++ b/hdl/BUILD
@@ -51,26 +51,24 @@ bluespec_library('TestUtils',
 
 # Tests
 
-def test_module(name, library, module):
-    object_dep = name + '_object'
-    bluespec_sim(object_dep,
-        top = library + '.bsv',
-        modules = [
-            module,
-        ],
-        deps = [
-            ':' + library,
-        ])
-    bluesim_binary(name,
-        env = 'bluesim_default',
-        top = ':%s#%s' % (object_dep, module),
-        deps = [
-            ':' + object_dep,
-        ])
+bluesim_tests('InitialResetTests',
+    env = 'bluesim_default',
+    suite = 'InitialReset.bsv',
+    modules = [
+        'mkInitialResetTest',
+    ])
 
-test_module('initial_reset_test', 'InitialReset', 'mkInitialResetTest')
+bluesim_tests('SchmittRegTests',
+    env = 'bluesim_default',
+    suite = 'SchmittReg.bsv',
+    modules = [
+        'mkFastEdgeSchmittRegTest',
+        'mkLongBounceSchmittRegTest',
+    ])
 
-test_module('fast_edge_schmitt_reg_test', 'SchmittReg', 'mkFastEdgeSchmittRegTest')
-test_module('long_bounce_schmitt_reg_test', 'SchmittReg', 'mkLongBounceSchmittRegTest')
-
-test_module('fractional_strobe_test', 'Strobe', 'mkFractionalStrobeTest')
+bluesim_tests('StrobeTests',
+    env = 'bluesim_default',
+    suite = 'Strobe.bsv',
+    modules = [
+        'mkFractionalStrobeTest',
+    ])

--- a/hdl/examples/BUILD
+++ b/hdl/examples/BUILD
@@ -13,20 +13,14 @@ bluespec_library('UARTLoopback',
         '//hdl/interfaces:UART',
     ])
 
-bluespec_sim('loopback_tests',
-    top = 'UARTLoopback.bsv',
+bluesim_tests('UARTLoopbackTests',
+    env = 'bluesim_default',
+    suite = 'UARTLoopback.bsv',
     modules = [
-        'mkUARTLoopbackTest'
+        'mkUARTLoopbackTest',
     ],
     deps = [
         ':UARTLoopback',
-    ])
-
-bluesim_binary('uart_loopback_test',
-    env = 'bluesim_default',
-    top = ':loopback_tests#mkUARTLoopbackTest',
-    deps = [
-        ':loopback_tests',
     ])
 
 #

--- a/hdl/interfaces/BUILD
+++ b/hdl/interfaces/BUILD
@@ -27,26 +27,13 @@ bluespec_library('UART',
         '//hdl:TestUtils',
     ])
 
-bluespec_sim('uart_tests',
-    top = 'UART.bsv',
+bluesim_tests('UARTTests',
+    env = 'bluesim_default',
+    suite = 'UART.bsv',
     modules = [
         'mkSerializerTest',
         'mkSerDesTest',
     ],
     deps = [
-        ':UART'
-    ])
-
-bluesim_binary('uart_serializer_test',
-    env = 'bluesim_default',
-    top = ':uart_tests#mkSerializerTest',
-    deps = [
-        ':uart_tests',
-    ])
-
-bluesim_binary('uart_serdes_test',
-    env = 'bluesim_default',
-    top = ':uart_tests#mkSerDesTest',
-    deps = [
-        ':uart_tests',
+        ':UART',
     ])

--- a/hdl/test/BUILD
+++ b/hdl/test/BUILD
@@ -1,33 +1,14 @@
 # -*- python -*- vim:syntax=python:
 
-bluespec_library('Encoding8b10bTest',
-    sources = [
-        'Encoding8b10bTest.bsv',
-    ],
-    deps = [
-        '//hdl:Encoding8b10b',
-        '//hdl:TestUtils',
-    ])
-
-bluespec_sim('encoding8b10b_tests',
-    top = 'Encoding8b10bTest.bsv',
+bluesim_tests('Encoding8b10bTests',
+    env = 'bluesim_default',
+    suite = 'Encoding8b10bTest.bsv',
     modules = [
         'mkEncoderTest',
         'mkConnectTest',
         'mkDisconnectTest',
     ],
     deps = [
-        ':Encoding8b10bTest',
+        '//hdl:Encoding8b10b',
+        '//hdl:TestUtils',
     ])
-
-def encoding8b10b_test(name, module):
-    bluesim_binary('8b10b_' + name,
-        env = 'bluesim_default',
-        top = ':encoding8b10b_tests#%s' % module,
-        deps = [
-            ':encoding8b10b_tests',
-        ])
-
-encoding8b10b_test('encoder_test', 'mkEncoderTest')
-encoding8b10b_test('serdes_connect_test', 'mkConnectTest')
-encoding8b10b_test('serdes_disconnect_test', 'mkDisconnectTest')

--- a/tools/site_cobble/bluespec.py
+++ b/tools/site_cobble/bluespec.py
@@ -405,6 +405,32 @@ def bluesim_binary(package, name, *,
         deps = deps,
     )
 
+@global_fn
+def bluesim_tests(name, *,
+        env,
+        suite,
+        modules = [],
+        deps = [],
+        local: Delta = {},
+        extra: Delta = {}):
+    # Add a simulation target and bluesim_binary targets to the build graph.
+    bluespec_sim(name,
+        top = suite,
+        modules = modules,
+        deps = deps,
+        local = local)
+    for test in modules:
+        test_name = '{}_{}'.format(name, test)
+
+        bluesim_binary(test_name,
+            env = env,
+            top = ':{}#{}'.format(name, test),
+            deps = [
+                ':' + name,
+            ],
+            local = local,
+            extra = extra)
+
 ninja_rules = {
     'compile_bluespec_obj': {
         'command': '$bsc $bsc_flags -bdir $bsc_bdir $in',


### PR DESCRIPTION
This diff adds a `bluesim_tests` macro to the `bluespec` Cobble plugin, allowing Bluesim test suites to be declared with much less overhead. For example:
```python
# hdl/test/BUILD

bluesim_tests('Encoding8b10bTests',
    env = 'bluesim_default',
    suite = 'Encoding8b10bTest.bsv',
    modules = [
        'mkEncoderTest',
        'mkConnectTest',
        'mkDisconnectTest',
    ],
    deps = [
        '//hdl:Encoding8b10b',
        '//hdl:TestUtils',
    ])
```
Resulting in the following build targets to be made available:
```
latest/hdl/test/Encoding8b10bTests_mkConnectTest
latest/hdl/test/Encoding8b10bTests_mkDisconnectTest
latest/hdl/test/Encoding8b10bTests_mkEncoderTest
```
See other BUILD files in this diff for additional examples.