### PR TITLE
Name Nextpnr bitstream outputs

### DIFF
--- a/tools/site_cobble/nextpnr.py
+++ b/tools/site_cobble/nextpnr.py
@@ -94,6 +94,7 @@ def _any_bitstream(package, name, *,
             implicit = [config_report_link],
             rule = 'pack_' + nextpnr_family_name + '_bitstream',
         )
+        bitstream.expose(path = bitstream_path, name = 'bitstream')
         bitstream.symlink(
             target = bitstream_path,
             source = package.linkpath(bitstream_out))


### PR DESCRIPTION
Name Nextpnr bitstream outputs in the Cobble build graph, allowing build commands like:
```
~/quartz/build$ ./cobble build //hdl/boards/ignition.*#bitstream
4 query result(s)
...
```