### PR TITLE
Enables use of bluespec's TriState module

### DIFF
--- a/BUILD.conf
+++ b/BUILD.conf
@@ -22,10 +22,12 @@ environment('default', contents = {
     ],
     'yosys': VARS.get('yosys', 'bin', default='yosys'),
     # Suppress warnings about translate_off and parallel_case since these
-    # are regularly found in BSC generated code.
+    # are regularly found in BSC generated code. Additionally, suppress warning
+    # about limited tri-state support as it is supported for our devices.
     'yosys_flags': [
         '-w', 'translate_off',
         '-w', 'parallel_case',
+        '-w', '"Yosys has only limited support for tri-state logic at the moment."',
     ],
 
     'cxx': VARS.get('c', 'cxx', default='c++'),

--- a/vnd/bluespec/BUILD
+++ b/vnd/bluespec/BUILD
@@ -108,8 +108,7 @@ VERILOG_FILES = [
     'SyncReset0.v',
     'SyncResetA.v',
     'SyncWire.v',
-    # TODO (arjen): Disabled until we figure out how to suppress the Yosys warning.
-    #'TriState.v',
+    'TriState.v',
     'UngatedClockMux.v',
     'UngatedClockSelect.v',
 ]


### PR DESCRIPTION
Originally it was "Disabled until we figure out how to suppress the Yosys warning." and, well, we can do that.