### PR TITLE
Include reset structs when resets are defined

### DIFF
--- a/tools/site_cobble/rdl_pkg/models.py
+++ b/tools/site_cobble/rdl_pkg/models.py
@@ -68,6 +68,12 @@ class Register:
     def packed_fields(self):
         return [x for x in self.fields if not isinstance(x, ReservedField)]
 
+    @property
+    def has_reset_definition(self):
+        # Get the reset value for all the fields. If we don't see None in any of them we have defined reset behavior
+        a = [x.get_property('reset') for x in self.fields if not isinstance(x, ReservedField)]
+        return False if None in a else True
+
     def elaborate(self):
         """
         Register elaboration consists of sorting the defined fields by the

--- a/tools/site_cobble/rdl_pkg/models.py
+++ b/tools/site_cobble/rdl_pkg/models.py
@@ -1,5 +1,7 @@
 from systemrdl import RegNode, FieldNode, RDLListener, AddrmapNode
 
+class UnsupportedRegisterSizeError(Exception):
+    pass
 
 class AddrMapListener(RDLListener):
     """
@@ -80,9 +82,11 @@ class Register:
         low index of the field. We then loop through the fields and
         determine the largest contiguous gaps in the definitions and creating
         ReservedFields that fill into these spaces. These are accumulated in
-        a gaps variable, and the gaps and fields are contactenated and
+        a gaps variable, and the gaps and fields are concatenated and
         re-sorted by low index again at the end.
         """
+        if self.width != 8:
+            raise UnsupportedRegisterSizeError(f"We only support 8bit registers at this time. Register {self.name} has a width of {self.width}")
         # sort fields descending by field.low bit
         self.fields.sort(key=lambda x: x.low, reverse=True)
         field_max_name = max(len(fld.name) for fld in self.fields)

--- a/tools/site_cobble/rdl_pkg/rdl_cli.py
+++ b/tools/site_cobble/rdl_pkg/rdl_cli.py
@@ -62,7 +62,6 @@ def main():
 
     # make a path:
     out_path = Path(args.out_dir)
-    infile_name = Path(args.input_file).stem
 
     # Dump Jinja template-based outputs (filter out .json)
     templated_output_filenames = [Path(x) for x in args.outputs if '.json' not in x]

--- a/tools/site_cobble/rdl_pkg/templates/regpkg_bsv.jinja2
+++ b/tools/site_cobble/rdl_pkg/templates/regpkg_bsv.jinja2
@@ -14,6 +14,15 @@ typedef struct {
     {% endfor %}
 {% set reg_name_camel = register.name|lower|to_camel_case(uppercamel=True) %}
 } {{ reg_name_camel }} deriving (Eq, FShow);
+{% if register.has_reset_definition %}
+// Reset value
+{{ reg_name_camel }} {{register.name|lower|to_camel_case}}SpecReset = {{ reg_name_camel }}  {
+    {% for field in register.packed_fields %}
+        {% set name =  register.format_field_name(field.name)|lower %}
+        {{ name }}: {{"unpack(" if field.width >1 else ""}}'h{{"{:x}".format(field.get_property('reset'))}}{{")" if field.width >1 else ""}}{{ ", " if not loop.last else "" }}
+    {% endfor %}
+};
+{% endif %}
 // Register offsets
 Integer {{register.name|lower|to_camel_case}}Offset = {{register.offset}};
 // Field mask definitions


### PR DESCRIPTION
New creates a `<name>SpecReset` structure of the defined type for getting access to the specified reset values.  This is only generated when all of the fields in the register have a defined reset value in the .rdl file. This allows use of this value programatically for reset or other logic without having to decode it manually.