### PR TITLE
Improve reset generation using defaultValue and fix stale git SHAs

### DIFF
--- a/tools/site_cobble/bsv_fpga_version.py
+++ b/tools/site_cobble/bsv_fpga_version.py
@@ -4,6 +4,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import json
+import pathlib
 import cobble.env
 from cobble.plugin import *
 from cobble.git_version import *
@@ -16,10 +18,37 @@ KEYS = frozenset([GEN_GIT_VERSION_BSV])
 _ver_keys = frozenset([GEN_GIT_VERSION_BSV.name, GIT_VERSION_CODE.name, GIT_VERSION_REV_SHA1_SHORT.name])
 
 
+# This is a *super* ugly hack to force ninja to to do the right thing
+# We're going to dump out the current sha + stuff into a json file *only* if it needs to be updated, and we'll make this file
+# an implicit dependency to make this run when necessary.
+# Cobble envs aren't available at this time since we don't have an environment and we can't rely on ninja unless we have a file
+# that changes so we're making a file that changes.
+config = GitVersionerConfig('git', 'main', '..', 1000, 48, "", "HEAD")
+versioner = GitVersioner(config)
+out = {
+    'sha': versioner.sha1,
+    'code': str(versioner.revision)
+}
+test_in = {
+    'sha': "",
+    'code': ""
+}
+
+try:
+    with open('git_sha_hack.json', 'r') as infile:
+        test_in = json.load(infile)
+except:
+    pass
+
+if (test_in['sha'] != out['sha']) or (test_in['code'] != out['code']):
+    print("Git sha changed, updating file")
+    with open('git_sha_hack.json', 'w') as outfile:
+      json.dump(out, outfile)
+
 @target_def
 def bsv_fpga_version(package, name, *,
         deps = [],
-        sources = [],
+        sources = ['./git_sha_hack.json'],
         local: Delta = {},
         using: Delta = {}):
     def mkusing(ctx):
@@ -46,7 +75,7 @@ def bsv_fpga_version(package, name, *,
 
 ninja_rules = {
     'gen_git_version_bsv': {
-        'command': ' python3 $gen_git_version_bsv $git_version_code $git_version_rev_sha1_short $out > $out',
+        'command': ' python3 $gen_git_version_bsv $out > $out',
         'description': 'gen_git_version_bsv.py $out',
     }
 }

--- a/tools/site_cobble/gen_git_version_bsv.py
+++ b/tools/site_cobble/gen_git_version_bsv.py
@@ -1,5 +1,5 @@
 import argparse
-
+import json
 from pathlib import Path
 from string import Template
 
@@ -7,8 +7,8 @@ from string import Template
 parser = argparse.ArgumentParser(
     formatter_class=argparse.ArgumentDefaultsHelpFormatter
 )
-parser.add_argument(dest='version_code', help="Integer version code")
-parser.add_argument(dest='short_sha', help="8 character short SHA")
+# parser.add_argument(dest='version_code', help="Integer version code")
+# parser.add_argument(dest='short_sha', help="8 character short SHA")
 parser.add_argument(dest='output_filename', help="string for bluespec package name")
 
 template = Template("""
@@ -27,8 +27,16 @@ endpackage
 if __name__ == '__main__':
     args = parser.parse_args()
 
-    version = f'{int(args.version_code, 0):x}'
-    sha = f'{int(args.short_sha, 16):x}'
+    # version = f'{int(args.version_code, 0):x}'
+    # sha = f'{int(args.short_sha, 16):x}'
+
+    with open('git_sha_hack.json', 'r') as infile:
+        f = json.load(infile)
+
+    my_code = f['code']
+    my_sha = f['sha'][:8]
+    version = f'{int(my_code, 0):x}'
+    sha = f'{int(my_sha, 16):x}'
 
     package_name = str(Path(args.output_filename).stem)
 

--- a/tools/site_cobble/rdl_pkg/templates/regpkg_bsv.jinja2
+++ b/tools/site_cobble/rdl_pkg/templates/regpkg_bsv.jinja2
@@ -1,6 +1,7 @@
-
 // This is a generated file using the RDL tooling. Do not edit by hand.
 package {{ output_stem }};
+
+import DefaultValue::*;
 
 {# Loop registers building out BSV packages #}
 {% for register in registers %}
@@ -14,15 +15,6 @@ typedef struct {
     {% endfor %}
 {% set reg_name_camel = register.name|lower|to_camel_case(uppercamel=True) %}
 } {{ reg_name_camel }} deriving (Eq, FShow);
-{% if register.has_reset_definition %}
-// Reset value
-{{ reg_name_camel }} {{register.name|lower|to_camel_case}}SpecReset = {{ reg_name_camel }}  {
-    {% for field in register.packed_fields %}
-        {% set name =  register.format_field_name(field.name)|lower %}
-        {{ name }}: {{"unpack(" if field.width >1 else ""}}'h{{"{:x}".format(field.get_property('reset'))}}{{")" if field.width >1 else ""}}{{ ", " if not loop.last else "" }}
-    {% endfor %}
-};
-{% endif %}
 // Register offsets
 Integer {{register.name|lower|to_camel_case}}Offset = {{register.offset}};
 // Field mask definitions
@@ -53,6 +45,17 @@ instance Bits#({{reg_name_camel}}, {{register.width}});
     endfunction: unpack
 
 endinstance
+{% if register.has_reset_definition %}
+// Reset value
+instance DefaultValue #({{ reg_name_camel }});
+    defaultValue = {{ reg_name_camel }} {
+    {% for field in register.packed_fields %}
+        {% set name =  register.format_field_name(field.name)|lower %}
+        {{ name }}: {{"unpack(" if field.width >1 else ""}}'h{{"{:x}".format(field.get_property('reset'))}}{{")" if field.width >1 else ""}}{{ ", " if not loop.last else "" }}
+    {% endfor %}
+    };
+endinstance
+{% endif %}
 
 instance Bitwise#({{reg_name_camel}});
     function {{reg_name_camel}} \& ({{reg_name_camel}} i1, {{reg_name_camel}} i2) =


### PR DESCRIPTION
Git fix:
I know this is a hack but this felt like the least-invasive way of solving this issue right now, and it limited the scope to changes in cobalt. Essentially we unconditionally run some code (on plugin import no less!) that gets the current git information and creates/updates a .json file in the build directory when necessary.  This file is *magically* added as an input dependency for the generated version bsv so ninja can build a dep map and "work".  The generation script now opens this generated json and deserializes it, using the values to generate the bsv. This better fits the ninja pattern of files and dependencies while basically ignoring the cobble fanciness.  We can't use cobble variables here because at import we have no env so none of the variables are accessible.  Fixes #23 

minor bsv register generator changes:
We now implement the defaltValue instance rather than a magic constant with a name, allowing users to `mkReg(defaultValue)` on any of these rather than having to lookup the name.  