### PR TITLE
Deal with RegFiles and nested address maps more correctly

### DIFF
--- a/RDL_EXAMPLES.md
+++ b/RDL_EXAMPLES.md
@@ -1,0 +1,64 @@
+In SystemRDL, the `addrmap` is considered an HDL boundary, so we generate package files for each `addrmap`
+as a unique, stand-alone artifact. These may contain one or more `regfile` instances.  We have additionally 
+special-cased generation of an `addrmap` containing only other `addrmap` instances as a special, top-level
+generation to aid in system composability.  An `addrmap` which has both subordinate `addrmaps` and registers
+is unsupported at this time and may result in unpredictable results.
+
+Normal address maps are defined in the BUILD file like so:
+```
+rdl('regs_pkg',
+    sources = [
+        'gimlet_seq_fpga_regs.rdl'  # <- RDL file with one addrmap instance and some number of registers/regfiles
+    ],
+    outputs = [
+        'GimletSeqFpgaRegs.bsv', # <- Requested output of the addrmap BSV package
+        'gimlet_sub_regs.html',  # <- Requested output of the html documentation for this addrmap
+        'gimlet_sub_regs.json',  # <- Requested output of the .json for software consumption of this addrmap
+    ]
+)
+bluespec_library('GimletSeqFpgaRegs',
+    sources = [
+        ':regs_pkg#GimletSeqFpgaRegs.bsv', # <- Bluespec rule for generated .bsv>
+    ],
+    deps = [
+        ':regs_pkg',
+    ])
+```
+
+If you have a higher-level address map that contains the lower level address maps, you do have to list all the subordinate address maps again, *and* the order needs be from bottom to top or the compiler will complain when it finds un-defined symbols.
+
+Assume the `fake_top.rdl` looks like this (an instantiation of 2 copies fo the previously defined gimlet_seq_fpga_regs.rdl):
+
+```
+addrmap top_level_map {
+    default regwidth = 8;
+    // Instantiate 2 gimlet maps to test nesting
+    gimlet_seq_fpga gimlet1;
+    gimlet_seq_fpga gimlet2;
+};
+```
+
+Here's what goes into the BUILD file:
+
+```
+rdl('regs_top',
+    sources = [
+        'gimlet_seq_fpga_regs.rdl', # <- Lowest RDL file with one addrmap (again, still used in above rule)
+        'fake_top.rdl' # <-Highest level RDL file with only address maps instantiated
+    ],
+    outputs = [
+        'GimletTopRegs.bsv',  # <- Top-level bsv file. Will contain only integer offsets and the flattened registers names for the whole project.
+        'gimlet_regs.html', # <- Top-level html file. Will contain a fully enumerated, flattened address map
+    ]
+)
+
+bluespec_library('GimletTopRegs',
+    sources = [
+        ':regs_top#GimletTopRegs.bsv',  # <- Generated Bluespec package rule for inclusion elsewhere
+    ],
+    deps = [
+        ':regs_top',
+    ])
+```
+
+

--- a/tools/site_cobble/rdl.py
+++ b/tools/site_cobble/rdl.py
@@ -80,7 +80,7 @@ def rdl(package, name, *,
 
 ninja_rules = {
     'rdl_script': {
-        'command': ' python3 $rdl_script --out-dir $rdl_odir $in $out',
+        'command': ' python3 $rdl_script --input $in --output $out',
         'description': 'making rdl outputs',
     }
 }

--- a/tools/site_cobble/rdl_pkg/demo.rdl
+++ b/tools/site_cobble/rdl_pkg/demo.rdl
@@ -45,4 +45,31 @@ addrmap gimlet_seq_fpga {
     a_reg_block r0;
     a_reg_block r1;
 
+    reg a1_output_type {
+        name = "A1 Outputs";
+        default sw = r;
+
+        field {
+            desc = "Enables V3P3_SP3_VDD_33_S5_A1 rail (SEQ_TO_SP3_V3P3_S5_EN pin)";
+        } V3P3_S5_EN[1] = 0;
+        field {
+            desc = "Enables V1P5_SP3_VDD_RTC_A1 rail (SEQ_TO_SP3_V1P5_RTC_EN pin)";
+        } V1P5_RTC_EN[1] = 0;
+        field {
+            desc = "Enables V1P8_SP3_VDD_18_S5_A1 rail (SEQ_TO_SP3_V1P8_S5_EN pin)";
+        } V1P8_S5_EN[1] = 0;
+        field {
+            desc = "Enables V0P9_SP3_VDD_SOC_S5_A1 rail (SEQ_TO_SP3_V0P9_S5_EN pin)";
+        } V0P9_S5_EN[1] = 0;
+        field {
+            desc = "De-asserted to processor after GroupA supplies are stable (10ms after S5 rails minimum) 
+            (SEQ_TO_SP3_RSMRST_V3P3_L net inverted from this register)";
+        } RSMRST[1] = 0;
+    };
+
+    a1_output_type A1_OUT_STATUS;
+    A1_OUT_STATUS->name = "A1 Output readbacks";
+    a1_output_type A1_DBG_OUT;
+    A1_DBG_OUT->name = "A1 Output debug control";
+
 };

--- a/tools/site_cobble/rdl_pkg/demo.rdl
+++ b/tools/site_cobble/rdl_pkg/demo.rdl
@@ -2,6 +2,21 @@
 // This is SystemRDL description of the sw-accesible registers in the Gimlet
 // Sequencer FPGA.
 
+regfile a_reg_block {
+    default regwidth = 8;
+    
+    reg {
+        name = "Identification 0";
+        default sw = r;
+        
+        field {
+            desc = "0x1";
+        } data[7:0] =  0x01;
+
+    } ID0;
+};
+
+
 addrmap gimlet_seq_fpga {
     name = "Gimlet Sequencer FPGA";
     desc = "Register description of the Gimlet Sequencer FPGA";
@@ -26,5 +41,8 @@ addrmap gimlet_seq_fpga {
             desc = "These bits enable the SPI interrupt and select the interrupt level";
         } INTLVL[1:0] = 0;
     } INTCTRL @ 0x1;
+
+    a_reg_block r0;
+    a_reg_block r1;
 
 };

--- a/tools/site_cobble/rdl_pkg/demo.rdl
+++ b/tools/site_cobble/rdl_pkg/demo.rdl
@@ -33,14 +33,14 @@ addrmap gimlet_seq_fpga {
         field {
             desc = "Second something bad bit";
         } ANOTHERBAD[2:2] = 0;
-    } STATUS @ 0x0;
+    } STATUS;
 
     reg {
         name = "Interrupt Control";
         field {
             desc = "These bits enable the SPI interrupt and select the interrupt level";
         } INTLVL[1:0] = 0;
-    } INTCTRL @ 0x1;
+    } INTCTRL;
 
     a_reg_block r0;
     a_reg_block r1;

--- a/tools/site_cobble/rdl_pkg/demo_top.rdl
+++ b/tools/site_cobble/rdl_pkg/demo_top.rdl
@@ -1,0 +1,6 @@
+addrmap top_level_map {
+    default regwidth = 8;
+    // Instantiate 2 gimlet maps to test nesting
+    gimlet_seq_fpga gimlet1;
+    gimlet_seq_fpga gimlet2;
+};

--- a/tools/site_cobble/rdl_pkg/demo_top.rdl
+++ b/tools/site_cobble/rdl_pkg/demo_top.rdl
@@ -3,4 +3,5 @@ addrmap top_level_map {
     // Instantiate 2 gimlet maps to test nesting
     gimlet_seq_fpga gimlet1;
     gimlet_seq_fpga gimlet2;
+    gimlet_seq_fpga gimlet3;
 };

--- a/tools/site_cobble/rdl_pkg/exporter.py
+++ b/tools/site_cobble/rdl_pkg/exporter.py
@@ -7,8 +7,8 @@ from jinja2 import Environment, FileSystemLoader
 from systemrdl.node import RootNode, Node
 from systemrdl import RDLWalker
 
-from models import AddrMapListener, Register, Field, ReservedField
-
+from models import Register, Field, ReservedField
+from listeners import BaseRegListener
 from utils import to_camel_case, to_snake_case
 
 from typing import Any, Dict, Union, Optional, List
@@ -20,10 +20,10 @@ class TemplatedOutput:
             '.html': 'regmap_html.jinja2',
             '.adoc': 'regmap_adoc.jinja2',
         }
-    def __init__(self, out_dir: PathLike, out_name: PathLike):
+    def __init__(self, out_dir: PathLike, out_name: PathLike, template_name=None):
         self.out_dir = out_dir
         self.out_name = out_name
-        self.template_name = self.known_templates.get(self.out_name.suffix, None)
+        self.template_name = self.known_templates.get(self.out_name.suffix, None) if template_name is None else template_name
         if self.template_name is None:
             raise Exception(f'No known template for {str(self.out_name)} specified output')
 
@@ -32,13 +32,8 @@ class TemplatedOutput:
         return self.out_dir / self.out_name.name
 
 
-class RegBlockExporter:
+class BaseExporter:
     def __init__(self, **kwargs):
-        """
-        constructor for the ADOC Exporter class
-        :param kwargs:
-        """
-
         # Check for any stray kwargs
         if kwargs:
             raise TypeError(f"got an unexpected keyword argument '{list(kwargs.keys())[0]}")
@@ -47,14 +42,77 @@ class RegBlockExporter:
         self.env = Environment(loader=FileSystemLoader(Path(__file__).parent / 'templates'), lstrip_blocks=True, trim_blocks=True)
         self.env.filters['to_camel_case'] = to_camel_case
         self.env.filters['to_snake_case'] = to_snake_case
+        self.templates = []
+        self.outputs = []
+
+    def _write_files(self, context):
+        # Loop our templates outputting files as requested.
+        for output in self.outputs:
+            stream = self.env.get_template(output.template_name).stream(context)
+            stream.dump(str(output.output_file))
+
+    
+
+class MapofMapsExporter(BaseExporter):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         # Sort of a hack for now, load our jinja templates into a list
+        self.templates = [
+            self.env.get_template('toplvl_bsv.jinja2'), 
+            self.env.get_template('regmap_html.jinja2'),
+            ]
+
+    def export(self, node: Node, path: Union[str, PathLike], output_names: List[str], **kwargs: 'Dict[str, Any]') -> None:
+        # Check for any stray kwargs
+        if kwargs:
+            raise TypeError(f"got an unexpected keyword argument '{list(kwargs.keys())[0]}")
+        
+                # Check for any stray kwargs
+        if kwargs:
+            raise TypeError(f"got an unexpected keyword argument '{list(kwargs.keys())[0]}")
+
+        if isinstance(node, RootNode):
+            node = node.top
+
+        if Path(path).is_dir:
+            out_directory = Path(path)
+        else:
+            out_directory = Path(path).parent
+
+         # Collect the requested outputs
+        for name in output_names:
+            if '.bsv' in str(name):
+                self.outputs.append(TemplatedOutput(out_directory, name, 'toplvl_bsv.jinja2'))
+            else:
+                self.outputs.append(TemplatedOutput(out_directory, name))
+        
+        # Walk the model and build a data structure in self.registers
+        regs_block = BaseRegListener()
+        RDLWalker().walk(node, regs_block)
+
+         # Inject some needed context into the Jinja templates
+        context = {
+            'output_stem': 'TBC',
+            'map_name': node.inst_name,
+            'Register': Register,
+            'Field': Field,
+            'ReservedField': ReservedField,
+            'isinstance': isinstance,
+            'registers': regs_block.registers,
+            'flatten_names': True,
+        }
+        self._write_files(context)
+
+
+
+class MapExporter(BaseExporter):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         self.templates = [
             # self.env.get_template('regmap_adoc.jinja2'), 
             self.env.get_template('regpkg_bsv.jinja2'), 
             self.env.get_template('regmap_html.jinja2'),
             ]
-        self.registers = []
-        self.outputs = []
 
     def export(self, node: Node, path: Union[str, PathLike], output_names: List[str], **kwargs: 'Dict[str, Any]') -> None:
         """
@@ -81,22 +139,20 @@ class RegBlockExporter:
             self.outputs.append(TemplatedOutput(out_directory, name))
         
         # Walk the model and build a data structure in self.registers
-        RDLWalker().walk(node, AddrMapListener(self))
+        regs_block = BaseRegListener()
+        RDLWalker().walk(node, regs_block)
 
-       
-        
-        # Loop our templates outputting files as requested.
-        for output in self.outputs:
-            # Inject some needed context into the Jinja templates
-            context = {
-                'output_stem': output.out_name.stem,
-                'map_name': node.inst_name,
-                'Register': Register,
-                'Field': Field,
-                'ReservedField': ReservedField,
-                'isinstance': isinstance,
-                'registers': self.registers
-            }
-            stream = self.env.get_template(output.template_name).stream(context)
-            stream.dump(str(output.output_file))
+         # Inject some needed context into the Jinja templates
+        context = {
+            'output_stem': 'TBD',
+            'map_name': node.inst_name,
+            'Register': Register,
+            'Field': Field,
+            'ReservedField': ReservedField,
+            'isinstance': isinstance,
+            'registers': regs_block.registers,
+            'flatten_names': False,
+        }
+
+        self._write_files(context)
 

--- a/tools/site_cobble/rdl_pkg/listeners.py
+++ b/tools/site_cobble/rdl_pkg/listeners.py
@@ -1,0 +1,116 @@
+from systemrdl import RDLListener, AddrmapNode, RegfileNode, RegNode, FieldNode
+
+from models import Register, Field
+
+# Define a listener that will print out the register model hierarchy
+class MyModelPrintingListener(RDLListener):
+    def __init__(self):
+        self.indent = 0
+
+    # noinspection PyPep8Naming
+    def enter_Component(self, node):
+        if not isinstance(node, FieldNode):
+            print(" "*self.indent, node.get_path_segment())
+            self.indent += 4
+
+    # noinspection PyPep8Naming
+    def enter_Reg(self, node):
+        print(" "*self.indent, "Offset:", node.raw_address_offset)
+        print(" "*self.indent, "Address:", node.absolute_address)
+        print(node.get_property("name"))
+
+    # noinspection PyPep8Naming
+    def enter_Field(self, node):
+        # Print some stuff about the field
+        bit_range_str = "[%d:%d]" % (node.high, node.low)
+        sw_access_str = "sw=%s" % node.get_property("sw").name
+        print(" "*self.indent, bit_range_str, node.get_path_segment(), sw_access_str)
+
+    # noinspection PyPep8Naming
+    def exit_Component(self, node):
+        if not isinstance(node, FieldNode):
+            self.indent -= 4
+
+
+# Define a listener that will determine top Address map and other
+# lower-level address maps
+class PreExportListener(RDLListener):
+    def __init__(self):
+        self.maps = []  # List[Node]
+
+
+    def enter_Addrmap(self, node: AddrmapNode) -> None:
+        # If we're to top map, we only have AddrmapNodes as children
+        self.maps.append(node)
+    
+    @property
+    def is_map_of_maps(self):
+        return all(map(lambda x: isinstance(x, AddrmapNode), self.maps[0].children()))
+
+
+class BaseRegListener(RDLListener):
+    def __init__(self):
+        self.prefix_stack = []
+        self.known_types = []
+        self.cur_reg = None
+        self.registers = []
+    
+    def enter_Addrmap(self, node: AddrmapNode) -> None:
+        # print(f"Enter Addrmap: {node.inst_name}")
+        if not self.is_map_of_maps(node):  # skip appending the map of maps prefix
+            self.prefix_stack.append(node.inst_name)
+
+    def exit_Addrmap(self, node: AddrmapNode) -> None:
+        if not self.is_map_of_maps(node):  # skip popping the map of maps prefix
+            self.prefix_stack.pop()
+
+    def enter_Regfile(self, node: RegfileNode) -> None:
+        # print(f"Enter Regfile: {node.inst_name}")
+        self.prefix_stack.append(node.inst_name)
+
+    def exit_Regfile(self, node: RegfileNode) -> None:
+        self.prefix_stack.pop()
+    
+    def enter_Regfile(self, node: RegfileNode) -> None:
+        self.prefix_stack.append(node.inst_name)
+
+    def exit_Regfile(self, node: RegfileNode) -> None:
+        self.prefix_stack.pop()
+
+    def enter_Reg(self, node: RegNode) -> None:
+        # print(f"Enter reg: {node.inst_name}")
+        # print(f"stack: {self.prefix_stack}")
+        if node.type_name in self.known_types:
+            repeated_type = True
+        else:
+            self.known_types.append(node.type_name)
+            repeated_type = False
+        self.cur_reg = Register.from_node(node, self.prefix_stack, repeated_type)
+    
+
+    def exit_Reg(self, node):
+        """
+        When we exit a register, we know it's configuration is complete
+        so we run the elaborate method which sorts it, and enumerates
+        and fills in the reserved holes, and sorts again. This register
+        is then appended list of registers to be used
+        in generation of design collateral.
+        """
+        # print(f"Exit reg: {node.inst_name}")
+        self.cur_reg.elaborate()
+        self.registers.append(self.cur_reg)
+        self.cur_reg = None
+
+    def enter_Field(self, node) -> None:
+        # print(f"Enter Field: {node.inst_name}")
+        """
+        Each field we find, we generate a Field from the node and
+        append it to the fields list of our current register.
+        """
+        self.cur_reg.fields.append(Field.from_node(node))
+
+    @staticmethod
+    def is_map_of_maps(node):
+        return all(map(lambda x: isinstance(x, AddrmapNode), node.children()))
+
+    

--- a/tools/site_cobble/rdl_pkg/listeners.py
+++ b/tools/site_cobble/rdl_pkg/listeners.py
@@ -78,12 +78,23 @@ class BaseRegListener(RDLListener):
         self.prefix_stack.pop()
 
     def enter_Reg(self, node: RegNode) -> None:
+        # print(f"orig type name: {node.orig_type_name}")
+        # print(f"new type name: {node.type_name}")
+        # print(f"segment: {node.get_path_segment()}")
         # print(f"Enter reg: {node.inst_name}")
         # print(f"stack: {self.prefix_stack}")
-        if node.type_name in self.known_types:
+        # 2 cases here:
+        # node.orig_type_name is None, use node.type_name
+        # 
+
+
+        if (node.type_name in self.known_types) or (node.orig_type_name is not None and node.orig_type_name in self.known_types):
             repeated_type = True
         else:
-            self.known_types.append(node.type_name)
+            if node.orig_type_name is not None:
+                self.known_types.append(node.orig_type_name)
+            else:
+                self.known_types.append(node.type_name)
             repeated_type = False
         self.cur_reg = Register.from_node(node, self.prefix_stack, repeated_type)
     

--- a/tools/site_cobble/rdl_pkg/models.py
+++ b/tools/site_cobble/rdl_pkg/models.py
@@ -1,77 +1,45 @@
-from systemrdl import RegNode, FieldNode, RDLListener, AddrmapNode
+from typing import Optional, List
+
+from systemrdl import RegNode, FieldNode, AddrmapNode
 
 class UnsupportedRegisterSizeError(Exception):
     pass
 
-class AddrMapListener(RDLListener):
-    """
-    A listener that builds a simple list of registers each with a list
-    of fields.  Once a register is finished we do the elaborate() on
-    the register to discover holes, and insert a special kind of
-    "ReservedField" there. SystemRDL has no concept of missing
-    fields, but we need to know that to effectively generate proper
-    register maps, documentation and implementations.
-    """
-
-    def __init__(self, exporter):
-        """
-        It is expected that whatever the exporter is here, it has
-        an empty list-like attribute called "registers" since we
-        append to that.
-        """
-        self.exporter = exporter
-        self.cur_reg = None
-    
-    def enter_Addrmap(self, node: AddrmapNode) -> None:
-        self.exporter.map_name = node.inst_name;
-
-    def enter_Reg(self, node) -> None:
-        """
-        Each time we enter a register, we generate a new Register
-        from the node type and hold onto it here since we'll append
-        all our register's fields as we discover them.
-        """
-        self.cur_reg = Register.from_node(node)
-
-    def enter_Field(self, node) -> None:
-        """
-        Each field we find, we generate a Field from the node and
-        append it to the fields list of our current register.
-        """
-        self.cur_reg.fields.append(Field.from_node(node))
-
-    def exit_Reg(self, node):
-        """
-        When we exit a register, we know it's configuration is complete
-        so we run the elaborate method which sorts it, and enumerates
-        and fills in the reserved holes, and sorts again. This register
-        is then appended to the exporter's list of registers to be used
-        in generation of design collateral.
-        """
-        self.cur_reg.elaborate()
-        self.exporter.registers.append(self.cur_reg)
-        self.cur_reg = None
-
 
 class Register:
     @classmethod
-    def from_node(cls, node: RegNode):
-        return cls(node=node)
+    def from_node(cls, node: RegNode, prefix_stack, repeated_type=False):
+        return cls(node=node, prefix_stack=prefix_stack, repeated_type=repeated_type)
 
     def __init__(self, **kwargs):
+        self.prefix = '_'.join(kwargs.pop('prefix_stack'))
+        self.repeated_type = kwargs.pop('repeated_type')
         self.node = kwargs.pop('node')
         self.width = self.node.size * 8  # node.size is bytes, we want bits here
         self.name = self.node.get_path_segment()
-        self.offset = self.node.raw_address_offset
+        self.type_name = self.node.get_path_segment()
+        # Want offset from owning address map.
+        self.offset = self.node.absolute_address
         self.fields = []
-        self._max_field_name_chars = 6  # minimum is 6 for "zerosX"
+        self._max_field_name_chars = 0
+
+    @property
+    def prefixed_name(self):
+        return self.prefix + '_' + self.name
 
     @property
     def packed_fields(self):
+        """
+            Returns all the defined register fields, skipping any ReservedFields (undefined spaces)
+        """
         return [x for x in self.fields if not isinstance(x, ReservedField)]
 
     @property
     def has_reset_definition(self):
+        """
+            RDS doesn't force a reset definition on registers but we may want to conditionally generate
+            reset logic if a reset value was specified.
+        """
         # Get the reset value for all the fields. If we don't see None in any of them we have defined reset behavior
         a = [x.get_property('reset') for x in self.fields if not isinstance(x, ReservedField)]
         return False if None in a else True
@@ -87,10 +55,14 @@ class Register:
         """
         if self.width != 8:
             raise UnsupportedRegisterSizeError(f"We only support 8bit registers at this time. Register {self.name} has a width of {self.width}")
+        
         # sort fields descending by field.low bit
         self.fields.sort(key=lambda x: x.low, reverse=True)
         field_max_name = max(len(fld.name) for fld in self.fields)
+
+        # keep a running size of the largest field name to help with formatting
         self._max_field_name_chars = max(self._max_field_name_chars, field_max_name)
+        
         # find gaps and fill in with ReservedFields
         gaps = []
         expected = self.width - 1
@@ -101,7 +73,7 @@ class Register:
         if expected >= 0:
             gaps.append(ReservedField(expected, 0))
 
-        # Combine fields and re-sort
+        # Combine fields and re-sort, leaving us with a completely specified register
         self.fields = sorted(self.fields + gaps, key=lambda x: x.low, reverse=True)
 
     def format_field_name(self, name):
@@ -115,6 +87,9 @@ class Register:
         return f"{name:<{self._max_field_name_chars}}"
     
     def get_property(self, *args, **kwargs):
+        """
+        Helper function to get RDL property from this register node.
+        """
         try:
             prop = self.node.get_property(*args, **kwargs)
         except AttributeError:
@@ -129,6 +104,14 @@ class BaseField:
             return str(self.low)
         else:
             return f"{self.high}:{self.low}"
+
+    @property
+    def width(self):
+        return (self.high - self.low) + 1
+
+    @property
+    def mask(self):
+        return '{:02x}'.format(((1 << self.width) - 1) << self.low)
 
     def get_property(self, *args, **kwargs):
         try:
@@ -147,14 +130,9 @@ class Field(BaseField):
     def __init__(self, **kwargs):
         self.node = kwargs.pop('node')
         self.name = self.node.get_path_segment()
-        self.width = (self.node.high - self.node.low) + 1
         self.high = self.node.high
         self.low = self.node.low
         self.desc = self.node.get_property('desc')
-    
-    @property
-    def mask(self):
-        return '{:02x}'.format(((1 << self.width) - 1) << self.low)
 
 
 class ReservedField(BaseField):
@@ -162,7 +140,6 @@ class ReservedField(BaseField):
     def __init__(self, high, low):
         self.name = '-'
         self.node = None
-        self.width = (high - low) + 1
         self.high = high
         self.low = low
         self.desc = 'Reserved'

--- a/tools/site_cobble/rdl_pkg/models.py
+++ b/tools/site_cobble/rdl_pkg/models.py
@@ -17,7 +17,7 @@ class Register:
         self.node = kwargs.pop('node')
         self.width = self.node.size * 8  # node.size is bytes, we want bits here
         self.name = self.node.get_path_segment()
-        self.type_name = self.node.get_path_segment()
+        self.type_name = self.node.type_name if self.node.orig_type_name is None else self.node.orig_type_name
         # Want offset from owning address map.
         self.offset = self.node.absolute_address
         self.fields = []

--- a/tools/site_cobble/rdl_pkg/rdl_cli.py
+++ b/tools/site_cobble/rdl_pkg/rdl_cli.py
@@ -38,9 +38,8 @@ def main():
     pre_export = PreExportListener()
     RDLWalker().walk(root, pre_export)
 
-    # make a path:
-    out_path = Path(args.out_dir)
-    templated_output_filenames = [Path(x) for x in args.outputs if '.json' not in x]
+    output_filenames = [Path(x) for x in args.outputs]
+    output_filenames_no_json = [x for x in output_filenames if '.json' not in str(x)]
     # For a map of maps, we're going to generate:
     # Address offsets bsv using full address and flattening the naming
     # Address offsets json using full address and flattening the naming??
@@ -49,32 +48,22 @@ def main():
         # Dump Jinja template-based outputs (filter out .json)
         
         exporter = MapofMapsExporter()
-        exporter.export(pre_export.maps[0], out_path, templated_output_filenames)
+        exporter.export(pre_export.maps[0], output_filenames_no_json)
     else:
         # For each standard map, we're going to generate:
         # Standard bsv package from this base address
         # Standard json package from this base address
         # an HTML file of this block
-        # Dump Jinja template-based outputs (filter out .json)
-        templated_output_filenames = [Path(x) for x in args.outputs if '.json' not in x]
         exporter = MapExporter()
-        exporter.export(pre_export.maps[0], out_path, templated_output_filenames)
+        exporter.export(pre_export.maps[0], output_filenames_no_json)
     
-
-
-
-
-
-
-    
-    
-    # Dump json output if requested
-    json_files = [Path(x) for x in args.outputs if '.json' in x]
-    if len(json_files) == 1:
-        json_name = Path(json_files[0])
-        convert_to_json(rdlc, root, json_name)
-    elif len(json_files) > 1:
-        raise Exception(f'Specified too many .json outputs: {json_files.join(",")}')
+        # Dump json output if requested
+        json_files = [x for x in output_filenames if '.json' in str(x)]
+        if len(json_files) == 1:
+            json_name = Path(json_files[0])
+            convert_to_json(rdlc, root, json_name)
+        elif len(json_files) > 1:
+            raise Exception(f'Specified too many .json outputs: {json_files.join(",")}')
 
 args = parser.parse_args()
 

--- a/tools/site_cobble/rdl_pkg/templates/regmap_html.jinja2
+++ b/tools/site_cobble/rdl_pkg/templates/regmap_html.jinja2
@@ -263,7 +263,11 @@
     {# Loop over registers #}
     {% for register in registers %}
     <tr class="Register">
+        {% if flatten_names %}
+        <td class="RegisterName" colspan="3*">&nbsp;<a href="#" class="toggler" data-prod-cat="{{loop.index0}}">{{register.prefixed_name}}</a></td>
+        {% else %}
         <td class="RegisterName" colspan="3*">&nbsp;<a href="#" class="toggler" data-prod-cat="{{loop.index0}}">{{register.name}}</a></td>
+        {% endif %}
         <td class="Offset" colspan="2*">&nbsp;
             <div class="offset_tooltip">
                 {{"{:#0x}".format(register.offset)}}

--- a/tools/site_cobble/rdl_pkg/templates/regpkg_bsv.jinja2
+++ b/tools/site_cobble/rdl_pkg/templates/regpkg_bsv.jinja2
@@ -3,29 +3,42 @@ package {{ output_stem }};
 
 import DefaultValue::*;
 
+// ------------------------
+// Addrmap-specific defines
+// ------------------------
 {# Loop registers building out BSV packages #}
 {% for register in registers %}
 {% set reserved_cntr = namespace(value=0) %}
-// Register {{register.name}} definitions
+{% set reg_type_name_camel = register.type_name|lower|to_camel_case(uppercamel=True) %}
+Integer {{register.name|lower|to_camel_case}}Offset = {{register.offset}}; // struct {{reg_type_name_camel}}
+{% endfor %}
+
+
+// ---------------
+// Register types
+// ---------------
+{% for register in registers %}
+{% set reserved_cntr = namespace(value=0) %}
+{% set reg_type_name_camel = register.type_name|lower|to_camel_case(uppercamel=True) %}
+//
+// Register {{register.type_name}} definitions
+{% if not register.repeated_type %}
 typedef struct {
     {% for field in register.packed_fields %}
         {% set field_type = "Bit#({})".format(field.width) %}
         {% set name =  register.format_field_name(field.name)|lower %}
         {{ "{:<18}".format(field_type)}} {{ name }};  // bit {{field.bitslice_str()}}    
     {% endfor %}
-{% set reg_name_camel = register.name|lower|to_camel_case(uppercamel=True) %}
-} {{ reg_name_camel }} deriving (Eq, FShow);
-// Register offsets
-Integer {{register.name|lower|to_camel_case}}Offset = {{register.offset}};
+} {{ reg_type_name_camel }} deriving (Eq, FShow);
 // Field mask definitions
     {% for field in register.fields %}
         {% if not isinstance(field, ReservedField) %}
     Bit#({{register.width}}) {{register.name|lower|to_camel_case}}{{register.format_field_name(field.name)|lower|to_camel_case(uppercamel=True)}} = 'h{{field.mask}};
         {% endif %}
     {% endfor %}
-// Register {{register.name}} custom type-classes
-instance Bits#({{reg_name_camel}}, {{register.width}});
-    function Bit#({{register.width}}) pack ({{reg_name_camel}} r);
+// Register {{register.type_name}} custom type-classes
+instance Bits#({{reg_type_name_camel}}, {{register.width}});
+    function Bit#({{register.width}}) pack ({{reg_type_name_camel}} r);
         Bit#({{register.width}}) bts =  'h00;
         {% for field in register.fields %}
         {% if not isinstance(field, ReservedField) %}
@@ -34,21 +47,19 @@ instance Bits#({{reg_name_camel}}, {{register.width}});
         {% endfor %}
         return bts;
     endfunction: pack
-    function {{reg_name_camel}} unpack (Bit#({{register.width}}) b);
-        let r = {{reg_name_camel}} {
+    function {{reg_type_name_camel}} unpack (Bit#({{register.width}}) b);
+        let r = {{reg_type_name_camel}} {
         {% for field in register.packed_fields %}
-        {{register.format_field_name(field.name).strip()|lower}}: b[{{field.bitslice_str()}}] {{ ", " if not loop.last else "" }}
+            {{register.format_field_name(field.name).strip()|lower}}: b[{{field.bitslice_str()}}] {{ ", " if not loop.last else "" }}
         {% endfor %}
-        };
-        
+        };      
         return r;
     endfunction: unpack
-
 endinstance
 {% if register.has_reset_definition %}
 // Reset value
-instance DefaultValue #({{ reg_name_camel }});
-    defaultValue = {{ reg_name_camel }} {
+instance DefaultValue #({{ reg_type_name_camel }});
+    defaultValue = {{ reg_type_name_camel }} {
     {% for field in register.packed_fields %}
         {% set name =  register.format_field_name(field.name)|lower %}
         {{ name }}: {{"unpack(" if field.width >1 else ""}}'h{{"{:x}".format(field.get_property('reset'))}}{{")" if field.width >1 else ""}}{{ ", " if not loop.last else "" }}
@@ -56,29 +67,29 @@ instance DefaultValue #({{ reg_name_camel }});
     };
 endinstance
 {% endif %}
-
-instance Bitwise#({{reg_name_camel}});
-    function {{reg_name_camel}} \& ({{reg_name_camel}} i1, {{reg_name_camel}} i2) =
+// Bitwise operators
+instance Bitwise#({{reg_type_name_camel}});
+    function {{reg_type_name_camel}} \& ({{reg_type_name_camel}} i1, {{reg_type_name_camel}} i2) =
         unpack(pack(i1) & pack(i2));
-    function {{reg_name_camel}} \| ({{reg_name_camel}} i1, {{reg_name_camel}} i2) =
+    function {{reg_type_name_camel}} \| ({{reg_type_name_camel}} i1, {{reg_type_name_camel}} i2) =
         unpack(pack(i1) | pack(i2));
-    function {{reg_name_camel}} \^ ({{reg_name_camel}} i1, {{reg_name_camel}} i2) =
+    function {{reg_type_name_camel}} \^ ({{reg_type_name_camel}} i1, {{reg_type_name_camel}} i2) =
         unpack(pack(i1) ^ pack(i2));
-    function {{reg_name_camel}} \~^ ({{reg_name_camel}} i1, {{reg_name_camel}} i2) =
+    function {{reg_type_name_camel}} \~^ ({{reg_type_name_camel}} i1, {{reg_type_name_camel}} i2) =
         unpack(pack(i1) ~^ pack(i2));
-    function {{reg_name_camel}} \^~ ({{reg_name_camel}} i1, {{reg_name_camel}} i2) =
+    function {{reg_type_name_camel}} \^~ ({{reg_type_name_camel}} i1, {{reg_type_name_camel}} i2) =
         unpack(pack(i1) ^~ pack(i2));
-    function {{reg_name_camel}} invert ({{reg_name_camel}} i) =
+    function {{reg_type_name_camel}} invert ({{reg_type_name_camel}} i) =
         unpack(invert(pack(i)));
-    function {{reg_name_camel}} \<< ({{reg_name_camel}} i, t x) =
-        error("Left shift operation is not supported with type {{reg_name_camel}}");
-    function {{reg_name_camel}} \>> ({{reg_name_camel}} i, t x) =
-        error("Right shift operation is not supported with type {{reg_name_camel}}");
-    function Bit#(1) msb ({{reg_name_camel}} i) =
-        error("msb operation is not supported with type {{reg_name_camel}}");
-    function Bit#(1) lsb ({{reg_name_camel}} i) =
-        error("lsb operation is not supported with type {{reg_name_camel}}");
+    function {{reg_type_name_camel}} \<< ({{reg_type_name_camel}} i, t x) =
+        error("Left shift operation is not supported with type {{reg_type_name_camel}}");
+    function {{reg_type_name_camel}} \>> ({{reg_type_name_camel}} i, t x) =
+        error("Right shift operation is not supported with type {{reg_type_name_camel}}");
+    function Bit#(1) msb ({{reg_type_name_camel}} i) =
+        error("msb operation is not supported with type {{reg_type_name_camel}}");
+    function Bit#(1) lsb ({{reg_type_name_camel}} i) =
+        error("lsb operation is not supported with type {{reg_type_name_camel}}");
 endinstance
-
+{% endif %}
 {% endfor %}
 endpackage: {{ output_stem }}

--- a/tools/site_cobble/rdl_pkg/templates/regpkg_bsv.jinja2
+++ b/tools/site_cobble/rdl_pkg/templates/regpkg_bsv.jinja2
@@ -1,5 +1,5 @@
 // This is a generated file using the RDL tooling. Do not edit by hand.
-package {{ output_stem }};
+package {{ outputs.get_entity_name('.bsv') }};
 
 import DefaultValue::*;
 
@@ -20,9 +20,9 @@ Integer {{register.name|lower|to_camel_case}}Offset = {{register.offset}}; // st
 {% for register in registers %}
 {% set reserved_cntr = namespace(value=0) %}
 {% set reg_type_name_camel = register.type_name|lower|to_camel_case(uppercamel=True) %}
+{% if not register.repeated_type %}
 //
 // Register {{register.type_name}} definitions
-{% if not register.repeated_type %}
 typedef struct {
     {% for field in register.packed_fields %}
         {% set field_type = "Bit#({})".format(field.width) %}
@@ -92,4 +92,4 @@ instance Bitwise#({{reg_type_name_camel}});
 endinstance
 {% endif %}
 {% endfor %}
-endpackage: {{ output_stem }}
+endpackage: {{ outputs.get_entity_name('.bsv') }}

--- a/tools/site_cobble/rdl_pkg/templates/toplvl_bsv.jinja2
+++ b/tools/site_cobble/rdl_pkg/templates/toplvl_bsv.jinja2
@@ -1,0 +1,12 @@
+// This is a generated file using the RDL tooling. Do not edit by hand.
+package {{ output_stem }};
+// ------------------------
+// Addrmap-specific defines
+// ------------------------
+{# Loop registers building out BSV packages #}
+{% for register in registers %}
+{% set reserved_cntr = namespace(value=0) %}
+{% set reg_type_name_camel = register.type_name|lower|to_camel_case(uppercamel=True) %}
+Integer {{register.prefixed_name|lower|to_camel_case}}Offset = {{register.offset}}; // struct {{reg_type_name_camel}}
+{% endfor %}
+endpackage: {{ output_stem }}

--- a/tools/site_cobble/rdl_pkg/templates/toplvl_bsv.jinja2
+++ b/tools/site_cobble/rdl_pkg/templates/toplvl_bsv.jinja2
@@ -1,5 +1,5 @@
 // This is a generated file using the RDL tooling. Do not edit by hand.
-package {{ output_stem }};
+package {{ outputs.get_entity_name('.bsv') }};
 // ------------------------
 // Addrmap-specific defines
 // ------------------------
@@ -9,4 +9,4 @@ package {{ output_stem }};
 {% set reg_type_name_camel = register.type_name|lower|to_camel_case(uppercamel=True) %}
 Integer {{register.prefixed_name|lower|to_camel_case}}Offset = {{register.offset}}; // struct {{reg_type_name_camel}}
 {% endfor %}
-endpackage: {{ output_stem }}
+endpackage: {{ outputs.get_entity_name('.bsv') }}


### PR DESCRIPTION
Fixes #30.  RegFiles are now supported and work correctly.

Fixes #29. This now works in the following way:
- An AddrMap with only register and RegFile definitions generates like normal.
- An AddrMap containing a mix of AddrMaps and registers/Regfiles is not really tested but will likely generate like the first case, but totally flattened.
- An AddrMap containing other AddrMaps generates special bsv top file that just contains the offsets and an html map of the complete chip with flattened names.  Json output here is TBD.

A side-effect of this update is that types are now properly shared, meaning we only create a single struct and TypeClasses for this shared type, while still providing the enumerated offsets for each instance. 
- This can have minor code impact since the shared type name would not match the individual names you were using before.
- different defaulValues for this shared type aren't supported since defaultValue is done as a TypeClass.


Added RDL_EXAMPLES.md for examples of how this integrates with the BUILD files including nested addrmaps
