### PR TITLE
Add WriteOnceReg

### DIFF
--- a/hdl/BUILD
+++ b/hdl/BUILD
@@ -77,6 +77,11 @@ bluespec_library('TestUtils',
         'TestUtils.bsv',
     ])
 
+bluespec_library('WriteOnceReg',
+    sources = [
+        'WriteOnceReg.bsv',
+    ])
+
 # Tests
 
 bluesim_tests('CountdownTest',

--- a/hdl/WriteOnceReg.bsv
+++ b/hdl/WriteOnceReg.bsv
@@ -6,12 +6,25 @@
 
 package WriteOnceReg;
 
+export asWriteOnceReg;
+export asWriteOnceRegA;
+
+export mkWriteOnceReg;
+export mkWriteOnceRegA;
+export mkWriteOnceRegU;
+export mkWriteOnceConfigReg;
+export mkWriteOnceConfigRegA;
+export mkWriteOnceConfigRegU;
+
+import ConfigReg::*;
+
+
 //
 // `mkWriteOnceReg` is a thin wrapper around a `Reg#(t)`, allowing it to be
-// written only once. Subsequent writes to the register are silently ignored.
-// This can for example be used to implement write once soft fuses.
+// written only once. Subsequent writes to the register are silently ignored
+// which can for example be used to implement write once soft fuses.
 //
-module mkWriteOnceReg #(module#(Reg#(t)) m) (Reg#(t));
+module asWriteOnceReg #(module#(Reg#(t)) m) (Reg#(t));
     (* hide *) Reg#(t) _r <- m;
     Reg#(Bool) written <- mkReg(False);
 
@@ -25,11 +38,12 @@ module mkWriteOnceReg #(module#(Reg#(t)) m) (Reg#(t));
 endmodule
 
 //
-// `mkWriteOnceRegA` is a thin wrapper around a `Reg#(t)`, allowing it to be
-// written only once. Subsequent writes to the register are silently ignored.
-// This can for example be used to implement write once soft fuses.
+// `asWriteOnceRegA` is a thin wrapper around a `Reg#(t)`, allowing it to be
+// written only once. Subsequent writes to the register are silently ignored
+// which can for example be used to implement write once soft fuses. The state
+// for this wrapper is reset asynchronously.
 //
-module mkWriteOnceRegA #(module#(Reg#(t)) m) (Reg#(t));
+module asWriteOnceRegA #(module#(Reg#(t)) m) (Reg#(t));
     (* hide *) Reg#(t) _r <- m;
     Reg#(Bool) written <- mkRegA(False);
 
@@ -41,5 +55,35 @@ module mkWriteOnceRegA #(module#(Reg#(t)) m) (Reg#(t));
         end
     endmethod
 endmodule
+
+// Create a WriteOnce Reg with synchronous reset to the given init value.
+function module#(Reg#(t)) mkWriteOnceReg(t init)
+    provisos (Bits#(t, t_sz)) =
+        asWriteOnceReg(mkReg(init));
+
+// Create a WriteOnce Reg with asynchronous reset to the given init value.
+function module#(Reg#(t)) mkWriteOnceRegA(t init)
+    provisos (Bits#(t, t_sz)) =
+        asWriteOnceRegA(mkRegA(init));
+
+// Create a WriteOnce Reg without an explicit reset.
+function module#(Reg#(t)) mkWriteOnceRegU()
+    provisos (Bits#(t, t_sz)) =
+        asWriteOnceReg(mkRegU());
+
+// Create a WriteOnce ConfigReg with synchronous reset to the given init value.
+function module#(Reg#(t)) mkWriteOnceConfigReg(t init)
+    provisos (Bits#(t, t_sz)) =
+        asWriteOnceReg(mkConfigReg(init));
+
+// Create a WriteOnce ConfigReg with asynchronous reset to the given init value.
+function module#(Reg#(t)) mkWriteOnceConfigRegA(t init)
+    provisos (Bits#(t, t_sz)) =
+        asWriteOnceRegA(mkConfigRegA(init));
+
+// Create a WriteOnce ConfigReg without an explicit reset.
+function module#(Reg#(t)) mkWriteOnceConfigRegU()
+    provisos (Bits#(t, t_sz)) =
+        asWriteOnceReg(mkConfigRegU());
 
 endpackage

--- a/hdl/WriteOnceReg.bsv
+++ b/hdl/WriteOnceReg.bsv
@@ -1,0 +1,45 @@
+// Copyright 2022 Oxide Computer Company
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package WriteOnceReg;
+
+//
+// `mkWriteOnceReg` is a thin wrapper around a `Reg#(t)`, allowing it to be
+// written only once. Subsequent writes to the register are silently ignored.
+// This can for example be used to implement write once soft fuses.
+//
+module mkWriteOnceReg #(module#(Reg#(t)) m) (Reg#(t));
+    (* hide *) Reg#(t) _r <- m;
+    Reg#(Bool) written <- mkReg(False);
+
+    method t _read = _r._read;
+    method Action _write(t val);
+        if (!written) begin
+            _r <= val;
+            written <= True;
+        end
+    endmethod
+endmodule
+
+//
+// `mkWriteOnceRegA` is a thin wrapper around a `Reg#(t)`, allowing it to be
+// written only once. Subsequent writes to the register are silently ignored.
+// This can for example be used to implement write once soft fuses.
+//
+module mkWriteOnceRegA #(module#(Reg#(t)) m) (Reg#(t));
+    (* hide *) Reg#(t) _r <- m;
+    Reg#(Bool) written <- mkRegA(False);
+
+    method t _read = _r._read;
+    method Action _write(t val);
+        if (!written) begin
+            _r <= val;
+            written <= True;
+        end
+    endmethod
+endmodule
+
+endpackage


### PR DESCRIPTION
WriteOnceReg is a wrapper around Reg which allows it to be written only once. This can for example be used to implement soft fuses.