### PR TITLE
Fix SchmittReg tests, add slow filter test case

### DIFF
--- a/hdl/BUILD
+++ b/hdl/BUILD
@@ -103,7 +103,8 @@ bluesim_tests('SchmittRegTests',
     env = 'bluesim_default',
     suite = 'SchmittReg.bsv',
     modules = [
-        'mkFastEdgeSchmittRegTest',
+        'mkSlowEdgeSchmittRegTest',
+        'mkFastPositiveEdgeSchmittRegTest',
         'mkLongBounceSchmittRegTest',
     ])
 


### PR DESCRIPTION
This diff fixes the SchmittReg tests, which have been broken for a while. Once landed all current cobalt tests should run/pass as follows:
```
./cobble bluesim_test //.*Tests
```
Or from another repo which may depend on cobalt as a submodule:
```
./cobble bluesim_test cobalt//.*Tests
```