### PR TITLE
Make bluesim_debug env inherit from bluesim_default

### DIFF
--- a/BUILD.conf
+++ b/BUILD.conf
@@ -51,7 +51,7 @@ environment('bluesim_default', base = 'default', contents = {
     ],
 })
 
-environment('bluesim_debug', base = 'default', contents = {
+environment('bluesim_debug', base = 'bluesim_default', contents = {
     'bsc_flags': [
         '-keep-fires',
     ],


### PR DESCRIPTION
The `bluesim_debug` environment is intended to enable additional signals in waveform dumps to help understanding a design (at the expense of somewhat longer sim times due to additional logging). As such it should inherit from the `bluesim_default` environment.