### PR TITLE
Adding bsv enum generation from rdl enums

### DIFF
--- a/RDL_EXAMPLES.md
+++ b/RDL_EXAMPLES.md
@@ -61,4 +61,38 @@ bluespec_library('GimletTopRegs',
     ])
 ```
 
+Enums:
+======
+Note that bsv can't disambiguate enum members with the same name in the same package.
+```
+reg {
+        name = "A1 SM Status";
+        desc = "A1 'live' state machine status";
+        default sw = r;
 
+        enum a1_sm_status_enum {
+            Idle = 8'h00 {desc = "";};
+            Enable = 8'h01 {desc = "";};
+            WaitPG = 8'h02 {desc = "";};
+            Delay = 8'h03 {desc = "";};
+            Done = 8'h05 {desc = "";};
+        };
+
+        field {
+            desc = "TBD";
+            encode =  a1_sm_status_enum;
+        } A1SM[7:0];
+    } A1SMSTATUS;
+```
+
+This will generate enums in the bsv package as follows:
+```
+// Field Enum encoding
+typedef enum {
+    IDLE = 0, 
+    ENABLE = 1, 
+    WAITPG = 2, 
+    DELAY = 3, 
+    DONE = 5
+} A1smstatusA1sm deriving (Eq, Bits, FShow);
+```

--- a/tools/site_cobble/rdl_pkg/json_dump.py
+++ b/tools/site_cobble/rdl_pkg/json_dump.py
@@ -57,6 +57,11 @@ def convert_field(rdlc: RDLCompiler, obj: FieldNode) -> dict:
     write_se = None if (not obj.get_property('onwrite')) else obj.get_property('onwrite').name
     json_obj['se_onwrite'] = write_se
     json_obj['desc'] = obj.get_property('desc')
+    if obj.get_property('encode') is not None:
+        lst = list();
+        for name, value in list([(x.name, x.value) for x in obj.get_property("encode")]):
+            lst.append({"name": name, "value": value})
+        json_obj['encode'] = lst.copy()
     return json_obj
 
 

--- a/tools/site_cobble/rdl_pkg/listeners.py
+++ b/tools/site_cobble/rdl_pkg/listeners.py
@@ -22,6 +22,14 @@ class MyModelPrintingListener(RDLListener):
     # noinspection PyPep8Naming
     def enter_Field(self, node):
         # Print some stuff about the field
+        if node.get_property('encode') is not None:
+            my_enum = node.get_property('encode')
+            print("Encode: {}".format(my_enum.type_name))
+            print("Encode: {}".format(my_enum.members))
+            for i in my_enum:
+                print(f"Encode: {i.name}")
+                print(f"Encode: {i.value}")
+                print(f"Encode: {i.rdl_name}")
         bit_range_str = "[%d:%d]" % (node.high, node.low)
         sw_access_str = "sw=%s" % node.get_property("sw").name
         print(" "*self.indent, bit_range_str, node.get_path_segment(), sw_access_str)

--- a/tools/site_cobble/rdl_pkg/templates/regmap_html.jinja2
+++ b/tools/site_cobble/rdl_pkg/templates/regmap_html.jinja2
@@ -273,7 +273,7 @@
         <td class="Offset" colspan="2*">&nbsp;
             <div class="offset_tooltip">
                 {{"{:#0x}".format(register.offset)}}
-                {#<span class="tooltip_text">0xc8030000</span>#}
+                {#<span class="tooltip_text"></span>#}
             </div>
                 {#<div style="float:right;width:49%;text-align:right">(0)</div>#}
         </td>
@@ -319,10 +319,18 @@
     <tr class="cat{{outer_loop.index0}}" style="display: none">
         <td class="Blank" colspan="3*"></td>
         <td class="FieldDesc" colspan="2*">{{field.name}}</td>
-        <td class="FieldDesc" colspan="1*">{{ field.bitslice_str() }}</td>
+        <td class="FieldDesc" colspan="1*">{{field.bitslice_str() }}</td>
         <td class="FieldDesc" colspan="2*">{{field.get_property('sw').name}}</td>
-        <td class="FieldDesc" colspan="2*">{{field.get_property('reset')}}</td>
-        <td class="FieldDesc" colspan="14">{{field.desc}}</td>
+        <td class="FieldDesc" colspan="2*">{{field.reset_str}}</td>
+        <td class="FieldDesc" colspan="14">{{field.desc}}
+        {% if field.has_encode() %}
+        <br>
+        <br>
+        {% for enum_name, enum_val in field.encode_enums() %}
+            {{enum_name}} = {{"{:#0x}".format(enum_val)}} {{ "<br>" if not loop.last else "" }}
+        {% endfor %}
+        {% endif %}
+        </td>
     </tr>
     {% endif %}
     {% endfor %}

--- a/tools/site_cobble/rdl_pkg/templates/regpkg_bsv.jinja2
+++ b/tools/site_cobble/rdl_pkg/templates/regpkg_bsv.jinja2
@@ -39,6 +39,14 @@ typedef struct {
         {% if not isinstance(field, ReservedField) %}
 Bit#({{register.width}}) {{register.name|lower|to_camel_case}}{{register.format_field_name(field.name)|lower|to_camel_case(uppercamel=True)}} = 'h{{field.mask}};
         {% endif %}
+        {% if field.has_encode() %}
+// Field Enum encoding
+typedef enum {
+        {% for enum_name, enum_value in field.encode_enums() %}
+    {{enum_name|upper}} = {{enum_value}}{{ ", " if not loop.last else "" }}
+        {% endfor %}
+} {{register.name|lower|to_camel_case(uppercamel=True)}}{{register.format_field_name(field.name)|lower|to_camel_case(uppercamel=True)}} deriving (Eq, Bits, FShow);
+        {% endif %}
     {% endfor %}
 // Register {{register.type_name}} custom type-classes
 instance Bits#({{reg_type_name_camel}}, {{register.width}});

--- a/tools/site_cobble/rdl_pkg/templates/regpkg_bsv.jinja2
+++ b/tools/site_cobble/rdl_pkg/templates/regpkg_bsv.jinja2
@@ -43,7 +43,7 @@ Bit#({{register.width}}) {{register.name|lower|to_camel_case}}{{register.format_
 // Field Enum encoding
 typedef enum {
         {% for enum_name, enum_value in field.encode_enums() %}
-    {{enum_name|upper}} = {{enum_value}}{{ ", " if not loop.last else "" }}
+    {{enum_name}} = {{enum_value}}{{ ", " if not loop.last else "" }}
         {% endfor %}
 } {{register.name|lower|to_camel_case(uppercamel=True)}}{{register.format_field_name(field.name)|lower|to_camel_case(uppercamel=True)}} deriving (Eq, Bits, FShow);
         {% endif %}


### PR DESCRIPTION
This added RDL-specified enums to generate enums in the BSV package.  This is the first step in a series of steps to getting this end-end supported, but this was complete and useful now on the bsv side so I'm breaking this out separately.

Future work includes work on the rust generation side to generate Rust Enums also.  This was more invasive to our current Rust generation workflow and so will be done separately.

Right now, this fixes the html generation and the bsv package generation, leaving the json/rust stuff for future work.

Additionally, BSV has no way of disambiguating multiple enum members with the same name in the same package so we throw errors if you have conflicting enum names since we're generating one big package here.