### PR TITLE
Fix deprecated assert_* calls in video tests, use bluesim_test(..)

### DIFF
--- a/hdl/interfaces/video/BUILD
+++ b/hdl/interfaces/video/BUILD
@@ -1,10 +1,4 @@
-def bluesim_test(name, top, module):
-    bluesim_binary(name,
-        env = 'bluesim_default',
-        top = ':%s#%s' % (top, module),
-        deps = [
-            ':%s' % top,
-        ])
+# -*- python -*- vim:syntax=python:
 
 bluespec_library('video',
     sources = [
@@ -22,12 +16,9 @@ c_library('source_validation',
         'video_source_validation.cc',
     ])
 
-#
-# BlueSim targets
-#
-
-bluespec_sim('Timing_tests',
-    top = 'Timing.bsv',
+bluesim_tests('TimingTests',
+    env = 'bluesim_default',
+    suite = 'Timing.bsv',
     modules = [
         'mkMinimalDisplayTimingTest',
         'mk100pDisplayTimingTest',
@@ -36,8 +27,9 @@ bluespec_sim('Timing_tests',
         ':video',
     ])
 
-bluespec_sim('TestPatternGenerator_tests',
-    top = 'TestPatternGenerator.bsv',
+bluesim_tests('TestPatternGeneratorTests',
+    env = 'bluesim_default',
+    suite = 'TestPatternGenerator.bsv',
     modules = [
         'mkTestPatternGeneratorTest',
     ],
@@ -45,25 +37,12 @@ bluespec_sim('TestPatternGenerator_tests',
         ':video',
     ])
 
-bluespec_sim('TMDS_tests',
-    top = 'TMDS.bsv',
+bluesim_tests('TMDSTests',
+    env = 'bluesim_default',
+    suite = 'TMDS.bsv',
     modules = [
         'mkEncoderTest',
     ],
     deps = [
         ':video',
     ])
-
-#
-# Runnable tests
-#
-
-bluesim_test('minimal_display_timing_test', 'Timing_tests', 'mkMinimalDisplayTimingTest')
-bluesim_test('100p_display_timing_test', 'Timing_tests', 'mk100pDisplayTimingTest')
-
-bluesim_test(
-    'test_pattern_generator_test',
-    'TestPatternGenerator_tests',
-    'mkTestPatternGeneratorTest')
-
-bluesim_test('tmds_encoder_test', 'TMDS_tests', 'mkEncoderTest')

--- a/hdl/interfaces/video/TMDS.bsv
+++ b/hdl/interfaces/video/TMDS.bsv
@@ -182,10 +182,10 @@ module mkEncoderTest (Empty);
     endseq);
 
     mkAutoFSM(seq
-        assert_get_and_display_fshow(e.character, 'b11010_10100, "Expected control character");
-        assert_get_and_display_fshow(e.character, 'b10100_11100, "Expected TERC4 character");
-        assert_get_and_display_fshow(e.character, 'b10110_01100, "Expected guard band character");
-        assert_get_and_display_fshow(e.character, 'b10000_01100, "Expected pixel character");
+        assert_get_eq_display(e.character, 'b11010_10100, "Expected control character");
+        assert_get_eq_display(e.character, 'b10100_11100, "Expected TERC4 character");
+        assert_get_eq_display(e.character, 'b10110_01100, "Expected guard band character");
+        assert_get_eq_display(e.character, 'b10000_01100, "Expected pixel character");
     endseq);
 endmodule: mkEncoderTest
 

--- a/hdl/interfaces/video/TestPatternGenerator.bsv
+++ b/hdl/interfaces/video/TestPatternGenerator.bsv
@@ -131,15 +131,15 @@ module mkTestPatternGeneratorTest (Empty);
 
     mkAutoFSM(seq
         g.set_parameters(p);
-        assert_get_and_display_fshow(g.pixel, white, "expected a white pixel");
-        assert_get_and_display_fshow(g.pixel, white, "expected a white pixel");
-        assert_get_and_display_fshow(g.pixel, yellow, "expected a yellow pixel");
-        assert_get_and_display_fshow(g.pixel, cyan, "expected a cyan pixel");
-        assert_get_and_display_fshow(g.pixel, green, "expected a green pixel");
-        assert_get_and_display_fshow(g.pixel, magenta, "expected a magenta pixel");
-        assert_get_and_display_fshow(g.pixel, red, "expected a red pixel");
-        assert_get_and_display_fshow(g.pixel, blue, "expected a blue pixel");
-        assert_get_and_display_fshow(g.pixel, white, "expected a white pixel of the next line");
+        assert_get_eq_display(g.pixel, white, "expected a white pixel");
+        assert_get_eq_display(g.pixel, white, "expected a white pixel");
+        assert_get_eq_display(g.pixel, yellow, "expected a yellow pixel");
+        assert_get_eq_display(g.pixel, cyan, "expected a cyan pixel");
+        assert_get_eq_display(g.pixel, green, "expected a green pixel");
+        assert_get_eq_display(g.pixel, magenta, "expected a magenta pixel");
+        assert_get_eq_display(g.pixel, red, "expected a red pixel");
+        assert_get_eq_display(g.pixel, blue, "expected a blue pixel");
+        assert_get_eq_display(g.pixel, white, "expected a white pixel of the next line");
     endseq);
 
     mkTestWatchdog(20);


### PR DESCRIPTION
It looks like some video packages were missed in https://github.com/oxidecomputer/cobalt/pull/12 and https://github.com/oxidecomputer/cobalt/pull/41. This was discovered while working on build system improvements.