### PR TITLE
Generate build rule per delcared Verilog/Bluesim module

### DIFF
--- a/hdl/Countdown.bsv
+++ b/hdl/Countdown.bsv
@@ -61,7 +61,6 @@ instance Connectable#(PulseWire, Countdown#(sz));
     endmodule
 endinstance
 
-(* synthesize *)
 module mkCountdownTest (Empty);
     Countdown#(2) c <- mkCountdownBy1();
 

--- a/hdl/InitialReset.bsv
+++ b/hdl/InitialReset.bsv
@@ -30,7 +30,6 @@ module mkInitialReset #(Integer cycles) (Reset);
     return _ifc.gen_rst;
 endmodule
 
-(* synthesize *)
 module mkInitialResetTest (Empty);
     Reset initial_reset <- mkInitialReset(2);
     Reg#(Bool) r <- mkReg(True, reset_by initial_reset);

--- a/hdl/SchmittReg.bsv
+++ b/hdl/SchmittReg.bsv
@@ -97,7 +97,6 @@ endmodule
 
 // `mkSlowEdgeSchmittRegTest` tests a filter where three consequitive 0's or 1's
 // are required before the output generates a positive or negative edge.
-(* synthesize *)
 module mkSlowEdgeSchmittRegTest (Empty);
     let edge_patterns = EdgePatterns {
         negative_edge: 'b000,
@@ -122,7 +121,6 @@ endmodule
 // `mkFastPositiveEdgeSchmittRegTest` tests a filter where the output
 // immediately reflects a positive edge on the input but requires three
 // consequitive 0's before showing a falling edge.
-(* synthesize *)
 module mkFastPositiveEdgeSchmittRegTest (Empty);
     let edge_patterns = EdgePatterns {
         negative_edge: 'b000,
@@ -149,7 +147,6 @@ module mkFastPositiveEdgeSchmittRegTest (Empty);
     endseq);
 endmodule
 
-(* synthesize *)
 module mkLongBounceSchmittRegTest (Empty);
     let edge_patterns = EdgePatterns {
         negative_edge: 'b000,

--- a/hdl/Strobe.bsv
+++ b/hdl/Strobe.bsv
@@ -215,7 +215,6 @@ function Action tick_while_assert(
         dynamicAssert(s == pulse_expected, msg);
     endaction;
 
-(* synthesize *)
 module mkPowerTwoStrobeTest (Empty);
     // Expect a pulse 4th time `send()` is called.
     Strobe#(2) s <- mkPowerTwoStrobe(1, 0);
@@ -233,7 +232,6 @@ module mkPowerTwoStrobeTest (Empty);
     endseq);
 endmodule
 
-(* synthesize *)
 module mkPowerTwoStrobeAsCountDownTest (Empty);
     // Expect a pulse after two ticks.
     Strobe#(2) s <- mkPowerTwoStrobe(1, 0);
@@ -246,7 +244,6 @@ module mkPowerTwoStrobeAsCountDownTest (Empty);
     endseq);
 endmodule
 
-(* synthesize *)
 module mkFractionalStrobeTest (Empty);
     // Expect a pulse every ~10th tick, with an occasional 11th tick.
     Strobe#(16) s <- mkFractionalStrobe(1000 / 96, 0);
@@ -272,7 +269,6 @@ module mkFractionalStrobeTest (Empty);
     endseq);
 endmodule
 
-(* synthesize *)
 module mkLimitStrobeStrobeTest (Empty);
     // Expect a pulse 3rd time `send()` is called.
     Strobe#(2) s <- mkLimitStrobe(1, 3, 0);

--- a/hdl/boards/ecp5_evn/Examples.bsv
+++ b/hdl/boards/ecp5_evn/Examples.bsv
@@ -14,7 +14,7 @@ import UART::*;
 import UARTLoopback::*;
 
 
-(* synthesize, default_clock_osc="CLK_12mhz", default_reset="GSR_N" *)
+(* default_clock_osc="CLK_12mhz", default_reset="GSR_N" *)
 module mkBlinky (TopMinimal);
     GSR gsr <- mkGSR(); // Allow GSR_N to reset the design.
     Blinky#(12_000_000) blinky <- Blinky::mkBlinky();
@@ -33,7 +33,7 @@ module mkBlinky (TopMinimal);
     endmethod
 endmodule
 
-(* synthesize, default_clock_osc="CLK_12mhz", default_reset="GSR_N" *)
+(* default_clock_osc="CLK_12mhz", default_reset="GSR_N" *)
 module mkUARTLoopback (TopMinimal);
     GSR gsr <- mkGSR(); // Allow GSR_N to reset the design.
     UARTLoopback#(12_000_000, 115200, 8) loopback <- UARTLoopback::mkUARTLoopback();
@@ -60,7 +60,7 @@ endmodule
 // parts of a design using independent clocks. This example should blink the first two LEDs in phase
 // at 1Hz.
 //
-(* synthesize, default_clock_osc="CLK_12mhz", default_reset="GSR_N" *)
+(* default_clock_osc="CLK_12mhz", default_reset="GSR_N" *)
 module mkClocks (TopMinimal);
     GSR gsr <- mkGSR(); // Allow GSR_N to reset the design.
 

--- a/hdl/boards/icestick/Examples.bsv
+++ b/hdl/boards/icestick/Examples.bsv
@@ -13,7 +13,7 @@ import UART::*;
 import UARTLoopback::*;
 
 
-(* synthesize, default_clock_osc="clk_12mhz" *)
+(* default_clock_osc="clk_12mhz" *)
 module mkBlinky (Top);
     FTDI ftdi_noop <- mkFTDITieOff();
     IRDA irda_noop <- mkIRDATieOff();
@@ -24,7 +24,7 @@ module mkBlinky (Top);
     method led() = {'0, blinky.led()};
 endmodule
 
-(* synthesize, default_clock_osc="clk_12mhz" *)
+(* default_clock_osc="clk_12mhz" *)
 module mkUARTLoopback (Top);
     IRDA irda_noop <- mkIRDATieOff();
     UARTLoopback#(12_000_000, 115200, 8) loopback <- UARTLoopback::mkUARTLoopback();

--- a/hdl/boards/ulx3s/Examples.bsv
+++ b/hdl/boards/ulx3s/Examples.bsv
@@ -14,7 +14,7 @@ import UART::*;
 import UARTLoopback::*;
 
 
-(* synthesize, default_clock_osc="clk_25mhz", default_reset="btn_pwr" *)
+(* default_clock_osc="clk_25mhz", default_reset="btn_pwr" *)
 module mkBlinky (Top);
     GSR gsr <- mkGSR(); // Allow btn_pwr to reset the design.
     Blinky#(25_000_000) blinky <- Blinky::mkBlinky();
@@ -44,7 +44,7 @@ module mkBlinky (Top);
     endinterface
 endmodule
 
-(* synthesize, default_clock_osc="clk_25mhz", default_reset="btn_pwr" *)
+(* default_clock_osc="clk_25mhz", default_reset="btn_pwr" *)
 module mkUARTLoopback (Top);
     GSR gsr <- mkGSR(); // Allow btn_pwr to reset the design.
     UARTLoopback#(25_000_000, 115200, 8) loopback <- UARTLoopback::mkUARTLoopback();

--- a/hdl/examples/TestPatternVideoSource.bsv
+++ b/hdl/examples/TestPatternVideoSource.bsv
@@ -77,7 +77,6 @@ module mkFixedTimingTestPatternVideoSource
     method end_of_field = _source.end_of_field;
 endmodule
 
-(* synthesize *)
 module mk100pTestPatternVideoSource (FixedTimingTestPatternVideoSource);
     let timing = compute_timing(
         8, 8, 16, 160,  // H
@@ -92,7 +91,6 @@ module mk100pTestPatternVideoSource (FixedTimingTestPatternVideoSource);
     return _source;
 endmodule
 
-(* synthesize *)
 module mk480pTestPatternVideoSource (FixedTimingTestPatternVideoSource);
     let timing = compute_timing(
         16, 64, 80, 640, // H

--- a/hdl/examples/UARTLoopback.bsv
+++ b/hdl/examples/UARTLoopback.bsv
@@ -57,7 +57,6 @@ module mkUARTLoopback (UARTLoopback#(clk_freq, baud_rate, bit_period))
     method tx_strobe = transceiver.tx_strobe;
 endmodule
 
-(* synthesize *)
 module mkUARTLoopbackTest (Empty);
     UARTLoopback#(25_000_000, 115200, 8) loopback <- mkUARTLoopback();
 

--- a/hdl/interfaces/UART.bsv
+++ b/hdl/interfaces/UART.bsv
@@ -148,7 +148,6 @@ module mkSerializer (Serializer);
     endinterface
 endmodule: mkSerializer
 
-(* synthesize *)
 module mkSerializerTest (Empty);
     Serializer ser <- mkSerializer();
 
@@ -257,7 +256,6 @@ module mkDeserializer (Deserializer);
     method waiting_for_start = idle_or_stop;
 endmodule: mkDeserializer
 
-(* synthesize *)
 module mkSerDesTest (Empty);
     // 10 bit cycles + 2 cycles to latch input/ouput bytes + 1 cycle to assert output.
     mkTestWatchdog(10 + 2 + 1);

--- a/hdl/interfaces/video/TMDS.bsv
+++ b/hdl/interfaces/video/TMDS.bsv
@@ -168,7 +168,6 @@ module mkEncoder (Encoder);
     endmethod
 endmodule: mkEncoder
 
-(* synthesize *)
 module mkEncoderTest (Empty);
     Encoder e <- mkEncoder();
 

--- a/hdl/interfaces/video/TestPatternGenerator.bsv
+++ b/hdl/interfaces/video/TestPatternGenerator.bsv
@@ -121,7 +121,6 @@ module mkTestPatternGenerator (TestPatternGenerator);
     method set_parameters = parameters_next.wset;
 endmodule: mkTestPatternGenerator
 
-(* synthesize *)
 module mkTestPatternGeneratorTest (Empty);
     Parameters p = Parameters{
         pixels_per_column: 1,

--- a/hdl/interfaces/video/Timing.bsv
+++ b/hdl/interfaces/video/Timing.bsv
@@ -410,7 +410,6 @@ instance DefaultValue #(Counters);
         active: 0};
 endinstance
 
-(* synthesize *)
 module mkDisplayTimingGeneratorTest #(
         Timing t,
         Counters expected_pixels /*,
@@ -463,7 +462,6 @@ module mkDisplayTimingGeneratorTest #(
     endseq);
 endmodule
 
-(* synthesize *)
 module mkMinimalDisplayTimingTest (Empty);
     // 1 pixel/line for each period.
     let t = compute_timing(
@@ -479,7 +477,6 @@ module mkMinimalDisplayTimingTest (Empty);
     mkTestWatchdog(4 * 4 * 4); // ~4 frames.
 endmodule
 
-(* synthesize *)
 module mk100pDisplayTimingTest (Empty);
     let t = compute_timing(
         8, 8, 16, 160,  // H

--- a/hdl/test/Encoding8b10bTests.bsv
+++ b/hdl/test/Encoding8b10bTests.bsv
@@ -15,7 +15,6 @@ import TestUtils::*;
 
 // Encode all valid Values using the `encode(..)` functions from both packages,
 // comparing their results.
-(* synthesize *)
 module mkEncodeTest (Empty);
     Reg#(Bit#(9)) i <- mkReg(0);
     Wire#(Value) value <- mkWire();
@@ -53,7 +52,6 @@ endmodule
 // should match the `encode(..)` inputs. This is no guarantee the `decode(..)`
 // function will always return correct results, but it demonstrates it will
 // correctly decode the results of a valid encoder.
-(* synthesize *)
 module mkEncodeDecodeTest (Empty);
     Reg#(Bit#(9)) i <- mkReg(0);
     Wire#(Value) value <- mkWire();


### PR DESCRIPTION
Cobble takes a bit of a shotgun approach to generating Verilog/Bluesim modules from Bluespec package files; all modules in a file from which outputs should be generated are annotated with the `synthesize` attribute and BSC is called using the `-verilog` or `-sim` output mode. BSC then iterates through the package and sequentially generates output for each annotated module it finds. On the Cobble side the target declares a list of module outputs it expects to be generated. See for example https://github.com/oxidecomputer/cobalt/blob/d8020a844da9ddd4168b77c00e2577d995f1a425/hdl/BUILD#L112

This approach has served us well enough, but it has some drawbacks. One needs to remember to both list the module in the `BUILD` file as well as annotate it in the Bluespec package. Failure to do so results in build errors about missing files which may be unintuitive for new developers. But more importantly any time the package file (or any of its dependencies) changes BSC will regenerate all annotated modules. This is undesirable when a package contains a large (>10) number of modules, like in a unit test suite, or when generating the module takes significant amounts of time (sometimes this happens both). Moreover the outputs are generated sequentially using a single thread, so no available hardware parallelism is exploited even though generated modules do not have an order dependency.

This diff changes the above behavior by generating build rules for each module declared in the `BUILD` files, by passing the `-g` flag with the module name when requesting BSC to generate outputs from a package. This allows for two significant improvements; Ninja can schedule the generation of multiple modules in parallel, which significantly speeds up compiling larger tests suites, and it allows generating only a specific module the user is interested in, independent from how many modules are present in the package. This latter behavior is desirable when iterating on unit tests since long compile times really take the velocity out of development.

The above change does come with a catch; if modules in a file are annotated with the `synthesize` attribute `bsc` will generate its output regardless of whats requested using the `-g` flag. If these annotations are not removed Ninja will invoke BSC N times for N modules, and each of those invocations will generate all annotated modules in the package, which is strictly worse.

Anyway, some numbers to put this change in perspective. The first output is compiling and running a full test suite from scratch using a single build target, followed by an edit to the package file and the re-run of a single test:
```
dev@4b25b4b781b1:~/quartz/build$ ./cobble bluesim_test //hdl/ignition/test:MessageParserTests
14 query result(s)
[44/44] SYMLINK latest/hdl/ignition/test/MessageParserTests_mkParseVersionInvalidTest
                        //hdl/ignition/test:MessageParserTests
  PASS   (0:00:00.092)   .. mkParseChecksumInvalidTest
  PASS   (0:00:00.052)   .. mkParseHelloTest
  PASS   (0:00:00.052)   .. mkParseIdle1PolarityInvertedTest
  PASS   (0:00:00.053)   .. mkParseIdle1Test
  PASS   (0:00:00.054)   .. mkParseIdle2PolarityInvertedTest
  PASS   (0:00:00.051)   .. mkParseIdle2Test
  PASS   (0:00:00.050)   .. mkParseMessageTypeInvalidTest
  PASS   (0:00:00.050)   .. mkParseOrderedSetInvalidTest
  PASS   (0:00:00.051)   .. mkParseRequestInvalidTest
  PASS   (0:00:00.050)   .. mkParseStatusTest
  PASS   (0:00:00.052)   .. mkParseSystemPowerOffRequestTest
  PASS   (0:00:00.052)   .. mkParseSystemPowerOnRequestTest
  PASS   (0:00:00.050)   .. mkParseSystemResetRequestTest
  PASS   (0:00:00.051)   .. mkParseVersionInvalidTest

Build Time:             0:02:53.946
Test Time:              0:00:00.772
Total/Passed/Failed:    14/14/0

dev@4b25b4b781b1:~/quartz/build$ ./cobble bluesim_test //hdl/ignition/test:MessageParserTests_mkParseStatusTest
1 query result(s)
[3/3] BLUESIM env/47bcbda607f5f4d62cfb4209fa97c9a80b9030b3/hdl/ignition/test/mkParseStatusTest.ba
                        //hdl/ignition/test:MessageParserTests
  PASS   (0:00:00.051)   .. mkParseStatusTest

Build Time:             0:02:50.020
Test Time:              0:00:00.052
Total/Passed/Failed:    1/1/0
```
As you can see running a single test takes almost as long as compiling and running the entire test suite since BSC will compile all modules sequentially before the test runner can run the one we're interested in.

Now with the change applied, generating a build rule per module:
```
dev@4b25b4b781b1:~/quartz/build$ ./cobble bluesim_test //hdl/ignition/test:MessageParserTests
14 query result(s)
[118/118] SYMLINK latest/hdl/ignition/test/MessageParserTests_mkParseOrderedSetInvalidTest
                        //hdl/ignition/test:MessageParserTests
  PASS   (0:00:00.059)   .. mkParseChecksumInvalidTest
  PASS   (0:00:00.057)   .. mkParseHelloTest
  PASS   (0:00:00.050)   .. mkParseIdle1PolarityInvertedTest
  PASS   (0:00:00.052)   .. mkParseIdle1Test
  PASS   (0:00:00.050)   .. mkParseIdle2PolarityInvertedTest
  PASS   (0:00:00.055)   .. mkParseIdle2Test
  PASS   (0:00:00.052)   .. mkParseMessageTypeInvalidTest
  PASS   (0:00:00.049)   .. mkParseOrderedSetInvalidTest
  PASS   (0:00:00.054)   .. mkParseRequestInvalidTest
  PASS   (0:00:00.053)   .. mkParseStatusTest
  PASS   (0:00:00.053)   .. mkParseSystemPowerOffRequestTest
  PASS   (0:00:00.055)   .. mkParseSystemPowerOnRequestTest
  PASS   (0:00:00.051)   .. mkParseSystemResetRequestTest
  PASS   (0:00:00.049)   .. mkParseVersionInvalidTest

Build Time:             0:00:39.884
Test Time:              0:00:00.753
Total/Passed/Failed:    14/14/0

dev@4b25b4b781b1:~/quartz/build$ ./cobble bluesim_test //hdl/ignition/test:MessageParserTests_mkParseStatusTest
1 query result(s)
[3/3] BLUESIM env/932410aeabfeefa07216eb8276e80617651a7bf0/hdl/ignition/test/mkParseStatusTest.ba
                        //hdl/ignition/test:MessageParserTests
  PASS   (0:00:00.049)   .. mkParseStatusTest

Build Time:             0:00:15.313
Test Time:              0:00:00.049
Total/Passed/Failed:    1/1/0
```
As can be seen from this output, it takes both significantly less time to build the entire test suite (because ninja can invoke BSC in parallel for compilation of the modules, allowing additional cores and memory to be used) and to run a single changed test. The latter 15 seconds to build and run a single test is a significant improvement to developer velocity because you can stay in the flow.