### PR TITLE
Fix continuous assertion failing not resulting in test failure

### DIFF
--- a/tools/site_cobble/bluespec.py
+++ b/tools/site_cobble/bluespec.py
@@ -571,7 +571,7 @@ def bluesim_test(subparsers):
             # the output for failures.
             if not self.result == self.Result.FAIL:
                 for line in self.output:
-                    if line.startswith('Dynamic assertion failed'):
+                    if 'assertion failed' in line:
                         self.result = self.Result.FAIL
 
         @property


### PR DESCRIPTION
As per the comment a few lines above this diff, bluesim does not signal an assertion failing using exit codes. Instead the `bluesim_test` runner observes test output and fails a test if it finds assertion failures. Unfortunately that filter was a bit specific allowing continuous assertion failures to go unnoticed.