### PR TITLE
RDL to vhdl register generation support

### DIFF
--- a/tools/site_cobble/rdl_pkg/exporter.py
+++ b/tools/site_cobble/rdl_pkg/exporter.py
@@ -9,7 +9,7 @@ from systemrdl import RDLWalker
 
 from models import Register, Field, ReservedField, Memory
 from listeners import BaseListener
-from utils import to_camel_case, to_snake_case
+from utils import to_camel_case, to_snake_case, vhdl_2k8bitstring
 
 from typing import Any, Dict, List
 
@@ -18,6 +18,7 @@ class TemplatedOutput:
             '.bsv': 'regpkg_bsv.jinja2',
             '.html': 'regmap_html.jinja2',
             '.adoc': 'regmap_adoc.jinja2',
+            '.vhd': 'regpkg_vhdl.jinja2',
         }
     def __init__(self, out_name: PathLike, template_name=None):
         self.full_output_path = out_name
@@ -49,6 +50,7 @@ class BaseExporter:
         self.env = Environment(loader=FileSystemLoader(Path(__file__).parent / 'templates'), lstrip_blocks=True, trim_blocks=True)
         self.env.filters['to_camel_case'] = to_camel_case
         self.env.filters['to_snake_case'] = to_snake_case
+        self.env.filters['vhdl_2k8bitstring'] = vhdl_2k8bitstring
         self.templates = []
         self.outputs = []
 
@@ -114,6 +116,7 @@ class MapExporter(BaseExporter):
             # self.env.get_template('regmap_adoc.jinja2'), 
             self.env.get_template('regpkg_bsv.jinja2'), 
             self.env.get_template('regmap_html.jinja2'),
+            self.env.get_template('regpkg_vhdl.jinja2')
             ]
 
     def export(self, node: Node, output_names: List[PathLike], **kwargs: 'Dict[str, Any]') -> None:

--- a/tools/site_cobble/rdl_pkg/rdl_cli.py
+++ b/tools/site_cobble/rdl_pkg/rdl_cli.py
@@ -11,7 +11,7 @@ from listeners import PreExportListener, MyModelPrintingListener
 from json_dump import convert_to_json
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--input', nargs="+", dest='input_file', help='Explicity input list')
+parser.add_argument('--input', '--inputs', nargs="+", dest='input_file', help='Explicity input list')
 parser.add_argument('--out-dir', dest='out_dir', default=Path.cwd(), help='Output directory')
 parser.add_argument('--debug', action="store_true", default=False)
 parser.add_argument('--outputs', nargs="+", help="Explicit output list")

--- a/tools/site_cobble/rdl_pkg/templates/regmap_html.jinja2
+++ b/tools/site_cobble/rdl_pkg/templates/regmap_html.jinja2
@@ -319,7 +319,7 @@
     <tr class="cat{{outer_loop.index0}}" style="display: none">
         <td class="Blank" colspan="3*"></td>
         <td class="FieldDesc" colspan="2*">{{field.name}}</td>
-        <td class="FieldDesc" colspan="1*">{{field.bitslice_str() }}</td>
+        <td class="FieldDesc" colspan="1*">{{field.bsv_bitslice_str() }}</td>
         <td class="FieldDesc" colspan="2*">{{field.get_property('sw').name}}</td>
         <td class="FieldDesc" colspan="2*">{{field.reset_str}}</td>
         <td class="FieldDesc" colspan="14">{{field.desc}}

--- a/tools/site_cobble/rdl_pkg/templates/regpkg_bsv.jinja2
+++ b/tools/site_cobble/rdl_pkg/templates/regpkg_bsv.jinja2
@@ -31,13 +31,13 @@ typedef struct {
     {% for field in register.packed_fields %}
         {% set field_type = "Bit#({})".format(field.width) %}
         {% set name =  register.format_field_name(field.name)|lower %}
-    {{ "{:<18}".format(field_type)}} {{ name }};  // bit {{field.bitslice_str()}}    
+    {{ "{:<18}".format(field_type)}} {{ name }};  // bit {{field.bsv_bitslice_str()}}    
     {% endfor %}
 } {{ reg_type_name_camel }} deriving (Eq, FShow);
 // Field mask definitions
     {% for field in register.fields %}
         {% if not isinstance(field, ReservedField) %}
-Bit#({{register.width}}) {{register.name|lower|to_camel_case}}{{register.format_field_name(field.name)|lower|to_camel_case(uppercamel=True)}} = 'h{{field.mask}};
+Bit#({{register.width}}) {{register.name|lower|to_camel_case}}{{register.format_field_name(field.name)|lower|to_camel_case(uppercamel=True)}} = 'h{{'{:02x}'.format(field.mask)}};
         {% endif %}
         {% if field.has_encode() %}
 // Field Enum encoding
@@ -54,7 +54,7 @@ instance Bits#({{reg_type_name_camel}}, {{register.width}});
         Bit#({{register.width}}) bts =  'h00;
         {% for field in register.fields %}
         {% if not isinstance(field, ReservedField) %}
-        bts[{{field.bitslice_str()}}] = r.{{register.format_field_name(field.name).strip()|lower}};
+        bts[{{field.bsv_bitslice_str()}}] = r.{{register.format_field_name(field.name).strip()|lower}};
         {% endif %}
         {% endfor %}
         return bts;
@@ -62,7 +62,7 @@ instance Bits#({{reg_type_name_camel}}, {{register.width}});
     function {{reg_type_name_camel}} unpack (Bit#({{register.width}}) b);
         let r = {{reg_type_name_camel}} {
         {% for field in register.packed_fields %}
-            {{register.format_field_name(field.name).strip()|lower}}: b[{{field.bitslice_str()}}] {{ ", " if not loop.last else "" }}
+            {{register.format_field_name(field.name).strip()|lower}}: b[{{field.bsv_bitslice_str()}}] {{ ", " if not loop.last else "" }}
         {% endfor %}
         };      
         return r;

--- a/tools/site_cobble/rdl_pkg/templates/regpkg_vhdl.jinja2
+++ b/tools/site_cobble/rdl_pkg/templates/regpkg_vhdl.jinja2
@@ -1,5 +1,38 @@
 {% set module_name = outputs.get_entity_name('.vhd') %}
 -- This is a generated file using the RDL tooling. Do not edit by hand.
+--
+-------------------------------
+-- Register "API" Documentation
+-------------------------------
+--   Each register is defined as a VHDL record and the following functions
+--   are provided for use:
+--   unpack() takes a std_logic_vector of the register's width (including 
+--     reserved bits in their respective positions) and returns an instance
+--     of the register's record type with the appropriate bits set.
+--     Overloaded with a version that accepts unsigned vectors.
+--   pack() takes an instance of the register's record typ and returns a
+--     a std_logic_vector of the register's width with the appropriate bits 
+--     set, (including reserved bits in their respective positions).
+--     Overloaded with an unsigned() version as well
+--   compress() takes an instance of the register's record type and returns a
+--     a std_logic_vector of the register's width with the appropriate bits 
+--     set, skipping any reserved fields.
+--   uncompress() is the comlement of compress() taking a std_logic_vector 
+--     in a register's compressed form putting it back into the record type
+--   sizeof() returns an integer of the number of used bits in the register
+--   rec_reset abusing overload signatures to return the reset value for the
+--     register type as defined in the RDL
+--   "or","and", "xor" we provide overloads for logical bitwise functions for 
+--     the record type with itself on both sides, it on the left side with an 
+--     slv on the right, and it on the left side with an unsigned on the right.
+--     Note: In cases where enumerated types are used, these will properly 
+--       bitwise operate but doing bitwise operations on enumerated values is
+--       likely nonsensical.
+--   "not" we provide a convience overload for doing a bitwise not on the record itself
+--     as a unary operator without forcing the user to convert to bits.
+--     Note: In cases where enumerated types are used, this will properly 
+--       bitwise operate but doing bitwise operations on enumerated values is
+--       likely nonsensical.
 
 library ieee;
 use ieee.std_logic_1164.all;
@@ -21,9 +54,9 @@ package {{module_name}} is
     {% if not register.repeated_type and isinstance(register, Register) %}
       {% set reg_name = register.type_name|lower %}
       {% set reg_type_name = register.type_name|lower+'_type' %}
-  --
+  -- ---------------
   -- Register {{reg_name}} definitions
-  ------------------
+  -- ---------------
       {# Build out enum definitions if they exist #}
       {% for field in register.encoded_fields %}
         {% if loop.first %}
@@ -95,7 +128,7 @@ package body {{module_name}} is
   ---------------------------------------
         {% for field in register.encoded_fields %}
         {% if loop.first %}
-  -- enum encode/decode
+  -- enum {{reg_name}}_{{field.name|lower}} encode from bits
         {% endif %}
   function encode(slv : std_logic_vector({{field.width - 1}} downto 0)) return {{reg_name}}_{{field.name|lower}} is
       variable ret_enum : {{reg_name}}_{{field.name|lower}};
@@ -108,7 +141,7 @@ package body {{module_name}} is
       end case;
       return ret_enum;
   end encode;
-     
+  -- enum {{reg_name}}_{{field.name|lower}} decode to bits
   function decode(enum: {{reg_name}}_{{field.name|lower}}) return std_logic_vector is
       variable ret_vec: std_logic_vector({{field.width - 1}} downto 0) := (others => '0');
     begin
@@ -135,7 +168,7 @@ package body {{module_name}} is
     end unpack;
   function unpack (un : unsigned({{register.width - 1}} downto 0)) return {{reg_type_name}} is
     begin
-      -- convert to std_logic_vector and use the 1st pack function
+      -- convert to std_logic_vector and use the 1st unpack function
       return unpack(std_logic_vector(un));
     end unpack;
   function pack (rec : {{reg_type_name}}) return std_logic_vector is
@@ -266,5 +299,6 @@ package body {{module_name}} is
     return ret_rec;
     end "not";
     {% endif %}
+
   {% endfor %}
 end {{module_name}};

--- a/tools/site_cobble/rdl_pkg/templates/regpkg_vhdl.jinja2
+++ b/tools/site_cobble/rdl_pkg/templates/regpkg_vhdl.jinja2
@@ -1,0 +1,270 @@
+{% set module_name = outputs.get_entity_name('.vhd') %}
+-- This is a generated file using the RDL tooling. Do not edit by hand.
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+package {{module_name}} is
+  -- ------------------------
+  -- Addrmap-specific defines
+  -- ------------------------
+  {# Loop registers #}
+  {% for register in registers %}
+    constant {{register.name|upper}}_OFFSET : integer := {{register.offset}};
+  {% endfor %}
+
+  -- ---------------
+  -- Register types
+  -- ---------------
+  {% for register in registers %}
+    {% if not register.repeated_type and isinstance(register, Register) %}
+      {% set reg_name = register.type_name|lower %}
+      {% set reg_type_name = register.type_name|lower+'_type' %}
+  --
+  -- Register {{reg_name}} definitions
+  ------------------
+      {# Build out enum definitions if they exist #}
+      {% for field in register.encoded_fields %}
+        {% if loop.first %}
+  -- Register-specific Enums
+        {% endif %}
+  type {{reg_name}}_{{field.name|lower}} is (
+          {% for enum_name, enum_val in field.encode_enums() %}
+    {{enum_name|upper}}{% if not loop.last %}, -- {{enum_val}}
+    {% else %}); -- {{enum_val}}
+    {% endif %}
+          {% endfor %}
+      {% endfor %}
+  
+  type {{reg_type_name}} is record
+      {% for field in register.packed_fields %}
+        {% if field.has_encode() %}
+      {{field.name}}  : {{reg_name}}_{{field.name|lower}};
+        {% elif field.width > 1 %}
+        {# Todo: fix for slv by custom property? #}
+      {{field.name}}{{' : unsigned(%s downto 0);' % (field.width-1)}}
+        {% elif field.width == 1 %}
+      {{field.name}}    : std_logic;
+        {%endif%}
+      {% endfor%}
+  end record;
+  -- register constants
+  -- field mask definitions
+      {% for field in register.packed_fields %}
+  constant {{register.name|upper}}_{{field.name|upper}}_MASK : std_logic_vector({{register.width - 1}} downto 0) := {{field.mask|vhdl_2k8bitstring(register.width)}};
+      {% endfor %}
+      {% for field in register.encoded_fields %}
+        {% if loop.first %}
+  -- some useful functions that operate on the register-specific enums
+        {% endif %}
+  function encode(slv : std_logic_vector({{field.width - 1}} downto 0)) return {{reg_name}}_{{field.name|lower}};
+  function decode(enum: {{reg_name}}_{{field.name|lower}}) return std_logic_vector;
+      {% endfor %}
+  -- some useful functions that operate on the <type> record
+  function unpack(slv : std_logic_vector({{register.width - 1}} downto 0)) return {{reg_type_name}};
+  function unpack(un : unsigned({{register.width - 1}} downto 0)) return {{reg_type_name}};
+  function pack(rec : {{reg_type_name}}) return std_logic_vector;
+  function pack(rec : {{reg_type_name}}) return unsigned;
+  function compress (rec : {{reg_type_name}}) return std_logic_vector;
+  function uncompress (vec : std_logic_vector) return {{reg_type_name}};
+  function sizeof (rec : {{reg_type_name}}) return integer;
+  function rec_reset return {{reg_type_name}};
+  function "or"  (left, right : {{reg_type_name}}) return {{reg_type_name}};
+  function "or"  (left : {{reg_type_name}}; right : std_logic_vector) return {{reg_type_name}};
+  function "or"  (left : {{reg_type_name}}; right : unsigned) return {{reg_type_name}};
+  function "and" (left, right : {{reg_type_name}}) return {{reg_type_name}};
+  function "and" (left : {{reg_type_name}}; right : std_logic_vector) return {{reg_type_name}};
+  function "and" (left : {{reg_type_name}}; right : unsigned) return {{reg_type_name}};
+  function "xor" (left, right : {{reg_type_name}}) return {{reg_type_name}};
+  function "xor" (left : {{reg_type_name}}; right : std_logic_vector) return {{reg_type_name}};
+  function "xor" (left : {{reg_type_name}}; right : unsigned) return {{reg_type_name}};
+  function "not" (right : {{reg_type_name}}) return {{reg_type_name}};
+    {% endif %}
+  {% endfor %}
+end {{module_name}};
+
+package body {{module_name}} is
+  {# Loop non-repeated registers needing implementation #}
+  {% for register in registers %}
+    {% if not register.repeated_type and isinstance(register, Register) %}
+      {% set reg_name = register.type_name|lower %}
+      {% set reg_type_name = register.type_name|lower+'_type' %}
+  ---------------------------------------
+  -- {{reg_type_name}} subprogram bodies
+  ---------------------------------------
+        {% for field in register.encoded_fields %}
+        {% if loop.first %}
+  -- enum encode/decode
+        {% endif %}
+  function encode(slv : std_logic_vector({{field.width - 1}} downto 0)) return {{reg_name}}_{{field.name|lower}} is
+      variable ret_enum : {{reg_name}}_{{field.name|lower}};
+    begin
+      case slv is
+          {% for enum_name, enum_value in field.encode_enums() %}
+        when {{enum_value|vhdl_2k8bitstring(field.width)}} => ret_enum := {{enum_name}};
+          {% endfor %}
+        when others => null;
+      end case;
+      return ret_enum;
+  end encode;
+     
+  function decode(enum: {{reg_name}}_{{field.name|lower}}) return std_logic_vector is
+      variable ret_vec: std_logic_vector({{field.width - 1}} downto 0) := (others => '0');
+    begin
+      case enum is
+          {% for enum_name, enum_value in field.encode_enums() %}
+        when {{enum_name}} => ret_vec := {{enum_value|vhdl_2k8bitstring(field.width)}};
+          {% endfor %}
+      end case;
+  end decode;
+      {% endfor %}
+  function unpack (slv : std_logic_vector({{register.width - 1}} downto 0)) return {{reg_type_name}} is
+      variable ret_rec : {{reg_type_name}};
+    begin
+      {% for field in register.packed_fields %}
+        {% if field.has_encode() %}
+        ret_rec.{{field.name}}:= encode(slv);
+        {% elif field.width > 1 %}
+        ret_rec.{{field.name}}:= unsigned(slv({{field.vhdl_bitslice_str()}}));
+        {% else %}
+        ret_rec.{{field.name}}:= slv({{field.vhdl_bitslice_str()}});
+        {% endif %}
+      {% endfor %}
+      return ret_rec;
+    end unpack;
+  function unpack (un : unsigned({{register.width - 1}} downto 0)) return {{reg_type_name}} is
+    begin
+      -- convert to std_logic_vector and use the 1st pack function
+      return unpack(std_logic_vector(un));
+    end unpack;
+  function pack (rec : {{reg_type_name}}) return std_logic_vector is
+      variable ret_vec : std_logic_vector({{register.width - 1}} downto 0) := (others => '0');
+    begin
+      {% for field in register.packed_fields %}
+          {% if field.has_encode() %}
+          ret_vec({{field.vhdl_bitslice_str()}}) := decode(rec.{{field.name}});
+          {% elif field.width > 1 %}
+            ret_vec({{field.vhdl_bitslice_str()}}) := std_logic_vector(rec.{{field.name}});
+          {% else %}
+            ret_vec({{field.vhdl_bitslice_str()}}) := rec.{{field.name}};
+          {% endif %}
+      {% endfor %}
+      return ret_vec;
+    end pack;
+    function pack (rec : {{reg_type_name}}) return unsigned is
+    begin
+      -- convert to std_logic_vector and use the 1st pack function
+      return unsigned(std_logic_vector'(pack(rec)));
+    end pack;
+    function compress (rec : {{reg_type_name}}) return std_logic_vector is
+        variable ret_vec : std_logic_vector({{register.used_bits - 1}} downto 0);
+    begin
+        {% set ns = namespace(bit = register.used_bits) %}
+        {% for field in register.packed_fields %}
+          {% if  field.has_encode() %}
+        ret_vec({{ns.bit-1}} downto {{ns.bit - field.width}}) := decode(rec.{{field.name}});
+          {% elif field.width == 1 %}
+        ret_vec({{ns.bit-1}}) := rec.{{field.name}};
+          {% else %}
+        ret_vec({{ns.bit-1}} downto {{ns.bit - field.width}}) := std_logic_vector(rec.{{field.name}});
+          {% endif %}
+          {% set ns.bit = ns.bit - field.width %}
+        {% endfor %}
+        return ret_vec;
+    end compress;
+    function uncompress (vec : std_logic_vector) return {{reg_type_name}} is
+        variable ret_rec : {{reg_type_name}};
+    begin
+        {% set ns = namespace(bit = register.used_bits) %}
+        {% for field in register.packed_fields %}
+          {% if  field.has_encode() %}
+        ret_rec.{{field.name}} := encode(vec({{ns.bit -1}} downto {{ns.bit-field.width}}));
+          {% elif field.width > 1 %}
+        ret_rec.{{field.name}} := unsigned(vec({{ns.bit -1}} downto {{ns.bit-field.width}}));
+          {% else %}
+        ret_rec.{{field.name}} := vec({{ns.bit -1}});
+          {% endif %}
+          {% set ns.bit = ns.bit - field.width %}
+        {% endfor %}
+        return ret_rec;
+    end uncompress;
+    function sizeof (rec : {{reg_type_name}}) return integer is
+    begin
+        return {{register.used_bits}};
+    end sizeof;
+    function rec_reset return {{reg_type_name}} is
+        variable ret_rec : {{reg_type_name}};
+    begin
+        {% for field in register.packed_fields %}
+          {% if field.has_encode() %}
+        ret_rec.{{field.name}} := encode({{field.vhdl_reset_or_default}});
+          {% else %}
+        ret_rec.{{field.name}} := {{field.vhdl_reset_or_default}};
+          {% endif %}
+        {% endfor %}
+        return ret_rec;
+    end rec_reset;
+    function "or" (left, right : {{reg_type_name}}) return {{reg_type_name}} is
+      variable ret_rec : {{reg_type_name}};
+    begin
+      ret_rec := unpack(std_logic_vector'(pack(left)) or std_logic_vector'(pack(right)));
+      return ret_rec;
+    end "or";
+    function "or" (left : {{reg_type_name}}; right : std_logic_vector) return {{reg_type_name}} is
+      variable ret_rec : {{reg_type_name}};
+    begin
+      ret_rec := unpack(std_logic_vector'(pack(left)) or right);
+    return ret_rec;
+    end "or";
+    function "or" (left : {{reg_type_name}}; right : unsigned) return {{reg_type_name}} is
+      variable ret_rec : {{reg_type_name}};
+    begin
+      ret_rec := unpack(unsigned'(pack(left)) or right);
+    return ret_rec;
+    end "or";
+    function "and" (left, right : {{reg_type_name}}) return {{reg_type_name}} is
+      variable ret_rec : {{reg_type_name}};
+    begin
+      ret_rec := unpack(std_logic_vector'(pack(left)) and std_logic_vector'(pack(right)));
+    return ret_rec;
+    end "and";
+    function "and" (left : {{reg_type_name}}; right : std_logic_vector) return {{reg_type_name}} is
+      variable ret_rec : {{reg_type_name}};
+    begin
+      ret_rec := unpack(std_logic_vector'(pack(left)) and right);
+    return ret_rec;
+    end "and";
+    function "and" (left : {{reg_type_name}}; right : unsigned) return {{reg_type_name}} is
+      variable ret_rec : {{reg_type_name}};
+    begin
+      ret_rec := unpack(unsigned'(pack(left)) and right);
+    return ret_rec;
+    end "and";
+    function "xor" (left, right : {{reg_type_name}}) return {{reg_type_name}} is
+      variable ret_rec : {{reg_type_name}};
+    begin
+      ret_rec := unpack(std_logic_vector'(pack(left)) xor std_logic_vector'(pack(right)));
+    return ret_rec;
+    end "xor";
+    function "xor" (left : {{reg_type_name}}; right : std_logic_vector) return {{reg_type_name}} is
+      variable ret_rec : {{reg_type_name}};
+    begin
+      ret_rec := unpack(std_logic_vector'(pack(left)) xor right);
+    return ret_rec;
+    end "xor";
+    function "xor" (left : {{reg_type_name}}; right : unsigned) return {{reg_type_name}} is
+      variable ret_rec : {{reg_type_name}};
+    begin
+      ret_rec := unpack(unsigned'(pack(left)) xor right);
+    return ret_rec;
+    end "xor";
+    function "not" (right : {{reg_type_name}}) return {{reg_type_name}} is
+      variable ret_rec : {{reg_type_name}};
+    begin
+      ret_rec := unpack(not std_logic_vector'(pack(right)));
+    return ret_rec;
+    end "not";
+    {% endif %}
+  {% endfor %}
+end {{module_name}};

--- a/tools/site_cobble/rdl_pkg/templates/regpkg_vhdl.jinja2
+++ b/tools/site_cobble/rdl_pkg/templates/regpkg_vhdl.jinja2
@@ -10,14 +10,14 @@
 --     reserved bits in their respective positions) and returns an instance
 --     of the register's record type with the appropriate bits set.
 --     Overloaded with a version that accepts unsigned vectors.
---   pack() takes an instance of the register's record typ and returns a
+--   pack() takes an instance of the register's record type and returns a
 --     a std_logic_vector of the register's width with the appropriate bits 
 --     set, (including reserved bits in their respective positions).
 --     Overloaded with an unsigned() version as well
 --   compress() takes an instance of the register's record type and returns a
 --     a std_logic_vector of the register's width with the appropriate bits 
 --     set, skipping any reserved fields.
---   uncompress() is the comlement of compress() taking a std_logic_vector 
+--   uncompress() is the complement of compress() taking a std_logic_vector 
 --     in a register's compressed form putting it back into the record type
 --   sizeof() returns an integer of the number of used bits in the register
 --   rec_reset abusing overload signatures to return the reset value for the
@@ -28,8 +28,9 @@
 --     Note: In cases where enumerated types are used, these will properly 
 --       bitwise operate but doing bitwise operations on enumerated values is
 --       likely nonsensical.
---   "not" we provide a convience overload for doing a bitwise not on the record itself
---     as a unary operator without forcing the user to convert to bits.
+--   "not" we provide a convenience overload for doing a bitwise not on the 
+--     record itself as a unary operator without forcing the user to convert to
+--     bits.
 --     Note: In cases where enumerated types are used, this will properly 
 --       bitwise operate but doing bitwise operations on enumerated values is
 --       likely nonsensical.

--- a/tools/site_cobble/rdl_pkg/utils.py
+++ b/tools/site_cobble/rdl_pkg/utils.py
@@ -8,3 +8,14 @@ def to_camel_case(template_string, uppercamel=False):
 
 def to_snake_case(template_string):
     return inflection.underscore(template_string)
+
+def vhdl_bitstring(template_string, size):
+    val = int(template_string,0)
+    return '"{0:0{1}b}"'.format(val,size)
+
+def vhdl_2k8bitstring(template_string, size):
+    if isinstance(template_string, str):
+        val = int(template_string, 0)
+    else:
+        val = template_string
+    return f'{size}x"{val:x}"'


### PR DESCRIPTION
1. Some fairly minor, and user-transparent changes to the data-model to support cleaner templates and a couple of template generation changes to match the existing implementation with these new properties etc. There should be no observed impact to existing bsv template outputs

1. A new template which generates a VHDL package for a given set of RDL inputs. 
    - Includes native enum generation and encode/decode functions from the 
    - The generated package includes an API comment describing the available functions
  
As was previously, the outputs you desire are chosen by extension of the names provided to the cli via the `--outputs` argument. If you want bsv outs your files should have .bsv in them, if you want vhdl you should have .vhd etc. This allows easy selection of desired outputs in cobble/buck2 build files.